### PR TITLE
251 save live video

### DIFF
--- a/peekingduck/configs/input/live.yml
+++ b/peekingduck/configs/input/live.yml
@@ -1,6 +1,7 @@
 input: ["source"]
-output: ["img"]
+output: ["img","filename","fps"]
 
+fps_saved_output_video: 10   #may need to change depending on user machine performance
 resize: {
             do_resizing: False,
             width: 1280,

--- a/peekingduck/configs/input/live.yml
+++ b/peekingduck/configs/input/live.yml
@@ -2,6 +2,7 @@ input: ["source"]
 output: ["img","filename","fps"]
 
 fps_saved_output_video: 10   #may need to change depending on user machine performance
+filename: webcamfeed.mp4
 resize: {
             do_resizing: False,
             width: 1280,

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import time
 from typing import Dict, Any
 
 from peekingduck.pipeline.nodes.node import AbstractNode
@@ -30,8 +31,11 @@ class Node(AbstractNode):
         self.resize_info = config['resize']
         input_source = config['input_source']
         mirror_image = config['mirror_image']
+        self.fps_saved_output_video = config["fps_saved_output_video"]
 
         self.videocap = VideoThread(input_source, mirror_image)
+
+        self._get_fps()
 
         width, height = self.videocap.resolution
         self.logger.info('Device resolution used: %s by %s', width, height)
@@ -47,7 +51,15 @@ class Node(AbstractNode):
                 img = resize_image(img,
                                    self.resize_info['width'],
                                    self.resize_info['height'])
-            outputs = {self.outputs[0]: img}
+            outputs = {self.outputs[0]: img, "fps":self.fps_saved_output_video,"filename":"webcamfeed.mp4"}
             return outputs
 
         raise Exception("An issue has been encountered reading the Image")
+
+    def _get_fps(self):
+        start_time = time.time()
+        for _ in range(10):
+           success, img = self.videocap.read_frame() 
+        end_time = time.time()
+
+        self.fps = 10/(end_time - start_time)

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import time
 from typing import Dict, Any
 
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -35,8 +35,6 @@ class Node(AbstractNode):
 
         self.videocap = VideoThread(input_source, mirror_image)
 
-        self._get_fps()
-
         width, height = self.videocap.resolution
         self.logger.info('Device resolution used: %s by %s', width, height)
         if self.resize_info['do_resizing']:
@@ -56,10 +54,4 @@ class Node(AbstractNode):
 
         raise Exception("An issue has been encountered reading the Image")
 
-    def _get_fps(self):
-        start_time = time.time()
-        for _ in range(10):
-           success, img = self.videocap.read_frame() 
-        end_time = time.time()
 
-        self.fps = 10/(end_time - start_time)

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -31,6 +31,7 @@ class Node(AbstractNode):
         input_source = config['input_source']
         mirror_image = config['mirror_image']
         self.fps_saved_output_video = config["fps_saved_output_video"]
+        self.filename = config["filename"]
 
         self.videocap = VideoThread(input_source, mirror_image)
 
@@ -48,9 +49,11 @@ class Node(AbstractNode):
                 img = resize_image(img,
                                    self.resize_info['width'],
                                    self.resize_info['height'])
-            outputs = {self.outputs[0]: img, "fps":self.fps_saved_output_video,"filename":"webcamfeed.mp4"}
+            outputs = {
+                self.outputs[0]: img,
+                "fps":self.fps_saved_output_video,
+                "filename":self.filename}
             return outputs
 
         raise Exception("An issue has been encountered reading the Image")
-
-
+        


### PR DESCRIPTION
To add functionality for live camera feed to save a video after model processing. Added filename and fps as outputs for live.py
filename = webcamfeed.mp4. fps = user input in live.yml.

Closes #251

