### PR TITLE
ci(cicd-infra): enable pull request code check

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -1,5 +1,5 @@
 name: Code Check
-on: push
+on: [push, pull_request]
 
 jobs:
   check_code:


### PR DESCRIPTION
Enable checks for pull request for opensource contributors. This means that github actions will run on pull requests even if the code was not originally on our branch.