### PR TITLE
Change license format

### DIFF
--- a/peekingduck/__init__.py
+++ b/peekingduck/__init__.py
@@ -12,5 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+A modular python framework for Computer Vision Inference
+"""
 
 __version__ = "developer"

--- a/peekingduck/__init__.py
+++ b/peekingduck/__init__.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 __version__ = "developer"

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import logging

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+CLI functions for Peekingduck
+"""
+
 import os
 import logging
 import yaml

--- a/peekingduck/loaders.py
+++ b/peekingduck/loaders.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Helper classes to load configs, nodes
+"""
+
 import sys
 import os
 import importlib

--- a/peekingduck/loaders.py
+++ b/peekingduck/loaders.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 import os

--- a/peekingduck/pipeline/__init__.py
+++ b/peekingduck/pipeline/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/__init__.py
+++ b/peekingduck/pipeline/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Nodes and pipelines to run PeekingDuck
+"""

--- a/peekingduck/pipeline/nodes/__init__.py
+++ b/peekingduck/pipeline/nodes/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/__init__.py
+++ b/peekingduck/pipeline/nodes/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Nodes for PeekingDuck inference workloads
+"""

--- a/peekingduck/pipeline/nodes/draw/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Draws results/outputs to an image
+"""

--- a/peekingduck/pipeline/nodes/draw/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""
+Draw bounding boxes over detected object
+"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/bbox_count.py
+++ b/peekingduck/pipeline/nodes/draw/bbox_count.py
@@ -1,16 +1,21 @@
-"""Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+"""
+Displays the counts of detected objects
+"""
 
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License."""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/draw/btm_midpoint.py
@@ -1,18 +1,21 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """
- Copyright 2021 AI Singapore
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- """
+Draws the lowest middle point of a bounding box
+"""
 
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/fps.py
+++ b/peekingduck/pipeline/nodes/draw/fps.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Displays the FPS of video
+"""
 
 from typing import Any, Dict
 from time import perf_counter

--- a/peekingduck/pipeline/nodes/draw/fps.py
+++ b/peekingduck/pipeline/nodes/draw/fps.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from time import perf_counter

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Draws detected groups and their tags
+"""
+
 from typing import Any, Dict, List
 
 import numpy as np

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Any, Dict, List
 
 import numpy as np

--- a/peekingduck/pipeline/nodes/draw/poses.py
+++ b/peekingduck/pipeline/nodes/draw/poses.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Draws keypoints on a detected pose
+"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/poses.py
+++ b/peekingduck/pipeline/nodes/draw/poses.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Displays a tag on bounding box
+"""
 
 from typing import Any, Dict
 

--- a/peekingduck/pipeline/nodes/draw/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/draw/utils/drawfunctions.py
+++ b/peekingduck/pipeline/nodes/draw/utils/drawfunctions.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+"""
+Utils, constants, and functions for drawing
+"""
+
 from typing import List, Tuple, Any, Iterable, Union
 import numpy as np
 import cv2

--- a/peekingduck/pipeline/nodes/draw/utils/drawfunctions.py
+++ b/peekingduck/pipeline/nodes/draw/utils/drawfunctions.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import List, Tuple, Any, Iterable, Union
 import numpy as np
 import cv2

--- a/peekingduck/pipeline/nodes/draw/zone_count.py
+++ b/peekingduck/pipeline/nodes/draw/zone_count.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode
@@ -35,5 +34,5 @@ class Node(AbstractNode):
             outputs (dict): Dict with keys "img".
         """
 
-        draw_zone_count(inputs['img'], inputs['zone_count']) # type: ignore
+        draw_zone_count(inputs['img'], inputs['zone_count'])  # type: ignore
         return {}

--- a/peekingduck/pipeline/nodes/draw/zone_count.py
+++ b/peekingduck/pipeline/nodes/draw/zone_count.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Displays counts of detected objects within a zone
+"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/zones.py
+++ b/peekingduck/pipeline/nodes/draw/zones.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Draws the 2D boundaries of a zone
+"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/draw/zones.py
+++ b/peekingduck/pipeline/nodes/draw/zones.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/heuristic/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Algorithms that performs calculations/heuristics on the outputs of `model`
+"""

--- a/peekingduck/pipeline/nodes/heuristic/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/heuristic/bbox_count.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_count.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 

--- a/peekingduck/pipeline/nodes/heuristic/bbox_count.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_count.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Counts the number of detected boxes
+"""
 
 from typing import Dict, Any
 

--- a/peekingduck/pipeline/nodes/heuristic/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_to_3d_loc.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 import numpy as np

--- a/peekingduck/pipeline/nodes/heuristic/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_to_3d_loc.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Estimates the 3D coordinates of an object given a 2D boundingbox
+"""
 
 from typing import Dict, Any
 import numpy as np

--- a/peekingduck/pipeline/nodes/heuristic/bbox_to_btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_to_btm_midpoint.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any, Tuple
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/heuristic/bbox_to_btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/heuristic/bbox_to_btm_midpoint.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Converts bounding boxes to a single point of reference
+"""
+
 
 from typing import Dict, Any, Tuple
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/heuristic/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/heuristic/check_large_groups.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict, List
 from collections import Counter

--- a/peekingduck/pipeline/nodes/heuristic/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/heuristic/check_large_groups.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Check if number of objects in a group exceed a threshold
+"""
 
 from typing import Any, Dict, List
 from collections import Counter

--- a/peekingduck/pipeline/nodes/heuristic/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/heuristic/check_nearby_objs.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Check if detected objects are near each other
+"""
+
 from typing import Dict, Any
 
 import numpy as np

--- a/peekingduck/pipeline/nodes/heuristic/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/heuristic/check_nearby_objs.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Dict, Any
 
 import numpy as np
@@ -22,6 +21,7 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 
 class Node(AbstractNode):
     """Node that checks if any objects are near to each other"""
+
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__(config, node_path=__name__)
         self.near_thres = config["near_threshold"]

--- a/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict, List, Tuple
 

--- a/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/heuristic/group_nearby_objs.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Assign objects in close proximity to groups
+"""
 
 from typing import Any, Dict, List, Tuple
 

--- a/peekingduck/pipeline/nodes/heuristic/keypoints_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/heuristic/keypoints_to_3d_loc.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Estimates the 3D coordinates of a human given 2D pose coordinates
+"""
 
 from typing import Dict, Any
 import numpy as np

--- a/peekingduck/pipeline/nodes/heuristic/keypoints_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/heuristic/keypoints_to_3d_loc.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 import numpy as np

--- a/peekingduck/pipeline/nodes/heuristic/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/utils/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Utility functions for heuristic nodes
+"""

--- a/peekingduck/pipeline/nodes/heuristic/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
+++ b/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+QuickFind algorithm used to connect nodes
+"""
 
 from typing import List
 

--- a/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
+++ b/peekingduck/pipeline/nodes/heuristic/utils/quick_find.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import List
 

--- a/peekingduck/pipeline/nodes/heuristic/zone_count.py
+++ b/peekingduck/pipeline/nodes/heuristic/zone_count.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import Dict, List, Any
 from peekingduck.pipeline.nodes.heuristic.zoningv1.zone import Zone
 from peekingduck.pipeline.nodes.node import AbstractNode
@@ -20,12 +18,13 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 
 class Node(AbstractNode):
     """Node that checks if any objects are near to each other"""
+
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__(config, node_path=__name__)
         zones_info = config["zones"]
         try:
-            self.zones = [self._create_zone(zone, config["resolution"]) \
-                for zone in zones_info]
+            self.zones = [self._create_zone(zone, config["resolution"])
+                          for zone in zones_info]
         except TypeError as error:
             self.logger.warning(error)
 
@@ -60,7 +59,7 @@ class Node(AbstractNode):
         if all(all(0 <= i <= 1 for i in coords) for coords in zone):
             # coordinates are in fraction. Use resolution to get correct coords
             pixel_coords = [self._get_pixel_coords(coords, resolution) for coords in zone]
-            created_zone =  Zone(pixel_coords)
+            created_zone = Zone(pixel_coords)
         if all(all((isinstance(i, int) and i >= 0) for i in coords) for coords in zone):
             # when 1st-if fails and this statement passes, list is in pixel value.
             created_zone = Zone(zone)
@@ -68,12 +67,12 @@ class Node(AbstractNode):
         # if neither, something is wrong
         if not created_zone:
             assert False, ("Zone %s needs to be all pixel-wise points or "
-            "all fractions of the frame between 0 and 1. "
-            "please check zone_count configs." % zone)
+                           "all fractions of the frame between 0 and 1. "
+                           "please check zone_count configs." % zone)
 
         return created_zone
 
     @staticmethod
-    def _get_pixel_coords(coords:List[float], resolution:List[int]) -> List[float]:
+    def _get_pixel_coords(coords: List[float], resolution: List[int]) -> List[float]:
         """returns the pixel position of the zone points"""
         return [int(coords[0] * resolution[0]), int(coords[1] * resolution[1])]

--- a/peekingduck/pipeline/nodes/heuristic/zone_count.py
+++ b/peekingduck/pipeline/nodes/heuristic/zone_count.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Counts the number of detected objects within a boundary
+"""
+
 from typing import Dict, List, Any
 from peekingduck.pipeline.nodes.heuristic.zoningv1.zone import Zone
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/heuristic/zoningv1/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/zoningv1/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/heuristic/zoningv1/__init__.py
+++ b/peekingduck/pipeline/nodes/heuristic/zoningv1/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Utility functions for zoning heuristic
+"""

--- a/peekingduck/pipeline/nodes/heuristic/zoningv1/zone.py
+++ b/peekingduck/pipeline/nodes/heuristic/zoningv1/zone.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Creats a zone from a polygon area
+"""
+
 from typing import List, Tuple
 from shapely.geometry.polygon import Polygon, Point
 

--- a/peekingduck/pipeline/nodes/heuristic/zoningv1/zone.py
+++ b/peekingduck/pipeline/nodes/heuristic/zoningv1/zone.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import List, Tuple
 from shapely.geometry.polygon import Polygon, Point
 

--- a/peekingduck/pipeline/nodes/input/__init__.py
+++ b/peekingduck/pipeline/nodes/input/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Reads data from a given input
+"""

--- a/peekingduck/pipeline/nodes/input/__init__.py
+++ b/peekingduck/pipeline/nodes/input/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 
@@ -51,9 +50,8 @@ class Node(AbstractNode):
                                    self.resize_info['height'])
             outputs = {
                 self.outputs[0]: img,
-                "fps":self.fps_saved_output_video,
-                "filename":self.filename}
+                "fps": self.fps_saved_output_video,
+                "filename": self.filename}
             return outputs
 
         raise Exception("An issue has been encountered reading the Image")
-        

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Reads a videofeed from a stream (e.g. webcam)
+"""
 
 from typing import Dict, Any
 

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Reads video/images from a directory
+"""
 
 import os
 from typing import Any, Dict

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import os
 from typing import Any, Dict

--- a/peekingduck/pipeline/nodes/input/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/input/utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/input/utils/preprocess.py
+++ b/peekingduck/pipeline/nodes/input/utils/preprocess.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import logging
 from typing import Any, Tuple

--- a/peekingduck/pipeline/nodes/input/utils/preprocess.py
+++ b/peekingduck/pipeline/nodes/input/utils/preprocess.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Preprocessing fuctions for input nodes
+"""
 
 import logging
 from typing import Any, Tuple

--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Tuple, Union
 from threading import Thread, Lock

--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Reader functions for input nodes
+"""
 
 from typing import Any, Tuple, Union
 from threading import Thread, Lock

--- a/peekingduck/pipeline/nodes/model/__init__.py
+++ b/peekingduck/pipeline/nodes/model/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Deep Learning model nodes for computer vision
+"""

--- a/peekingduck/pipeline/nodes/model/__init__.py
+++ b/peekingduck/pipeline/nodes/model/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.model.efficientdet_d04 import efficientdet_model

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Slower, accurate Object Detection model
+"""
+
+
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.model.efficientdet_d04 import efficientdet_model

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/__init__.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Core functions for EfficientDet nodes
+"""

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Detector class to handle detection of bboxes for efficientdet
+"""
+
 import os
 import logging
 import json

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/detector.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import os
 import logging
 import json

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/efficientnet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/efficientnet.py
@@ -23,6 +23,9 @@
 # Code of this model implementation is mostly written by
 # Björn Barz ([@Callidior](https://github.com/Callidior))
 
+"""
+EfficientNet parameters and constants
+"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/efficientnet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/efficientnet.py
@@ -1,29 +1,27 @@
-"""
-Copyright 2019 The TensorFlow Authors, Pavel Yakubovskiy, Björn Barz. All Rights Reserved.
-
-Modifications copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-==============================================================================
-Contains definitions for EfficientNet model.
-
-[1] Mingxing Tan, Quoc V. Le
-  EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks.
-  ICML'19, https://arxiv.org/abs/1905.11946
-
-Code of this model implementation is mostly written by
-Björn Barz ([@Callidior](https://github.com/Callidior))
-"""
+# Copyright 2019 The TensorFlow Authors, Pavel Yakubovskiy, Björn Barz. All Rights Reserved.
+#
+# Modifications copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Contains definitions for EfficientNet model.
+#
+# [1] Mingxing Tan, Quoc V. Le
+#   EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks.
+#   ICML'19, https://arxiv.org/abs/1905.11946
+#
+# Code of this model implementation is mostly written by
+# Björn Barz ([@Callidior](https://github.com/Callidior))
 
 
 from __future__ import absolute_import

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/initializers.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/initializers.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functions to control weights initialisation
+"""
+
+
 # import keras
 from typing import Any, Dict
 import math

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/initializers.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/initializers.py
@@ -1,21 +1,18 @@
-"""
-Copyright 2017-2018 Fizyr (https://fizyr.com)
-
-Modifications copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-"""
+# Copyright 2017-2018 Fizyr (https://fizyr.com)
+#
+# Modifications copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # import keras
 from typing import Any, Dict

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/layers.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/layers.py
@@ -15,6 +15,10 @@
 # Code of this file is mostly forked from
 # [@xuannianz](https://github.com/xuannianz))
 
+"""
+EfficientDet layers
+"""
+
 from typing import Any, Dict, List
 from tensorflow import keras
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/layers.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/layers.py
@@ -1,21 +1,20 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
-"""
 from typing import Any, Dict, List
 from tensorflow import keras
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model.py
@@ -15,6 +15,10 @@
 # Code of this file is mostly forked from
 # [@xuannianz](https://github.com/xuannianz))
 
+"""
+EfficientDet models
+"""
+
 from typing import Any, Callable, Tuple, List
 from functools import reduce
 

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/model.py
@@ -1,21 +1,20 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
-"""
 from typing import Any, Callable, Tuple, List
 from functools import reduce
 

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/tfkeras.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/tfkeras.py
@@ -15,6 +15,10 @@
 # Code of this file is mostly forked from
 # [@xuannianz](https://github.com/xuannianz))
 
+"""
+Inject Tensorflow Keras into model workloads
+"""
+
 
 from peekingduck.pipeline.nodes.model.efficientdet_d04.efficientdet_files.utils.keras_utils \
     import inject_tfkeras_modules, init_tfkeras_custom_objects

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/tfkeras.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/tfkeras.py
@@ -1,21 +1,21 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
-"""
 from peekingduck.pipeline.nodes.model.efficientdet_d04.efficientdet_files.utils.keras_utils \
     import inject_tfkeras_modules, init_tfkeras_custom_objects
 from peekingduck.pipeline.nodes.model.efficientdet_d04.efficientdet_files \

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/__init__.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Utilities for EfficientDet model
+"""

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/anchors.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/anchors.py
@@ -1,21 +1,25 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
+
+
 """
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
+Anchor-related functions for EfficientDet
 """
+
 
 from typing import Tuple, List, Callable
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/keras_utils.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/keras_utils.py
@@ -1,21 +1,25 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
+
 """
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
+Utilities to support Keras in EfficientDet
 """
+
+
 from typing import Any, Dict, Callable
 import functools
 import tensorflow.keras as tfkeras

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/model_process.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/model_process.py
@@ -1,20 +1,22 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
+
 """
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
+Processing helper functinos for EfficientDet
 """
 
 from typing import List, Tuple

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/submodule.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_files/utils/submodule.py
@@ -1,20 +1,22 @@
+# Copyright 2021 AI Singapore
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Code of this file is mostly forked from
+# [@xuannianz](https://github.com/xuannianz))
+
 """
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Code of this file is mostly forked from
-[@xuannianz](https://github.com/xuannianz))
+Utility functions to obtain submodules
 """
 
 from typing import Dict, Any, Tuple

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import logging
 from typing import Dict, Any, List, Tuple
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+EfficientDet model with model types: D0-D4
+"""
+
 import logging
 from typing import Dict, Any, List, Tuple
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Slower, accurate Pose Estimation model. Requires a object detector
+"""
+
 
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/model/hrnetv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Core functions for HRNet model
+"""

--- a/peekingduck/pipeline/nodes/model/hrnetv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Supporting functions for HRNet
+"""

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/detector.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import os
 import logging

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/detector.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Detector class to handle detection of poses for hrnet
+"""
 
 import os
 import logging

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/postprocessing.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/postprocessing.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Postprocessing functions for HRNet
+"""
+
+
 from typing import List, Tuple
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/postprocessing.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/postprocessing.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import List, Tuple
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/preprocessing.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/preprocessing.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Preprocessing functions for HRNet
+"""
+
 from typing import Tuple
 import numpy as np
 import cv2

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/preprocessing.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_files/preprocessing.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Tuple
 import numpy as np
 import cv2

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Main class for HRNet Model
+"""
+
+
 import logging
 from typing import Any, Dict, Tuple
 

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import logging
 from typing import Any, Dict, Tuple
 

--- a/peekingduck/pipeline/nodes/model/posenet.py
+++ b/peekingduck/pipeline/nodes/model/posenet.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Fast Pose Estimation model
+"""
+
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.model.posenetv1 import posenet_model

--- a/peekingduck/pipeline/nodes/model/posenet.py
+++ b/peekingduck/pipeline/nodes/model/posenet.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.model.posenetv1 import posenet_model

--- a/peekingduck/pipeline/nodes/model/posenetv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/posenetv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Core functions for PoseNet model"""

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Supporting functions for PoseNet
+"""

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/constants.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/constants.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Constants used for PoseNet
+"""
 
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/constants.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/constants.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode.py
@@ -10,6 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Support functions to decode single pose
+"""
+
+
 from typing import Tuple
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode.py
@@ -1,16 +1,15 @@
-"""
-Copyright 2018 Ross Wightman
-Modifications copyright 2021 AI Singapore
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-     https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2018 Ross Wightman
+# Modifications copyright 2021 AI Singapore
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Tuple
 import numpy as np
 

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode_multi.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode_multi.py
@@ -1,19 +1,18 @@
-"""
-Copyright 2018 Ross Wightman
-Modifications copyright 2021 AI Singapore
+# Copyright 2018 Ross Wightman
+# Modifications copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import List, Tuple
 
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode_multi.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/decode_multi.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Supporting functions to decode multiple poses
+"""
+
+
 from typing import List, Tuple
 
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/detector.py
@@ -1,16 +1,15 @@
-"""
-Copyright 2018 Ross Wightman
-Modifications copyright 2021 AI Singapore
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-     https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2018 Ross Wightman
+# Modifications copyright 2021 AI Singapore
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import List
 import numpy as np
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/detector.py
@@ -10,6 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Core functions to use posenet to detect poses
+"""
+
+
 from typing import List
 import numpy as np
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Predictor class to handle detection of poses for posenet
+"""
+
 import os
 import logging
 from typing import Dict, List, Callable, Any, Tuple

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/predictor.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import os
 import logging
 from typing import Dict, List, Callable, Any, Tuple

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/preprocessing.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/preprocessing.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 from typing import Tuple
 
 import cv2

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/preprocessing.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_files/preprocessing.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Preprocessing functions for PoseNet
+"""
+
 from typing import Tuple
 
 import cv2

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import logging
 from typing import Dict, Any, Tuple
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""PoseNet model with model types: mobilenet50, mobilenet75, mobilenet101 and resnet"""
+
 import logging
 from typing import Dict, Any, Tuple
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Fast Object Detection model
+"""
 
 from typing import Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/model/yolov4/__init__.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Yolo-related files for yolo node
+"""

--- a/peekingduck/pipeline/nodes/model/yolov4/__init__.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/__init__.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Yolo utilities
+"""

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/batch_norm.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/batch_norm.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import numpy as np
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/batch_norm.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/batch_norm.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Make trainable=False freeze BN
+"""
 
 import numpy as np
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/dataset.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/dataset.py
@@ -32,6 +32,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""
+Yolo image transformation
+"""
+
 import tensorflow as tf
 
 

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/dataset.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/dataset.py
@@ -1,38 +1,36 @@
-"""
-Modifications copyright 2021 AI Singapore
+# Modifications copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Original copyright (c) 2019 Zihao Zhang
+# Original copyright (c) 2019 Zihao Zhang
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 import tensorflow as tf
 

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
@@ -1,29 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-This is detection file that will be used to detect person bounding box with
-the confident score.
-
-Public function:
-    - detect_person(): return bounding box, score for person
-    - detect_person_and_plot_to_output_image(): plot output image
-
-Commands:
-    python src/yolov3/detector.py
-    python src/yolov3/detector.py --tiny
-"""
 import os
 import builtins
 from typing import Dict, Any, List, Tuple

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Object detection class using yolo model to find object bboxes
+"""
+
 import os
 import builtins
 from typing import Dict, Any, List, Tuple

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/models.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/models.py
@@ -1,38 +1,36 @@
-"""
-Modifications copyright 2021 AI Singapore
+# Modifications copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Original copyright (c) 2019 Zihao Zhang
+# Original copyright (c) 2019 Zihao Zhang
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 from typing import Union, List, Tuple
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/models.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/models.py
@@ -32,6 +32,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""
+Core Yolo model files
+"""
+
 from typing import Union, List, Tuple
 import numpy as np
 import tensorflow as tf

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/utils.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/utils.py
@@ -32,6 +32,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""
+Drawing functions for yolo
+"""
+
 from typing import List, Dict, Tuple, Any
 import numpy as np
 import cv2

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/utils.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/utils.py
@@ -1,38 +1,36 @@
-"""
-Modifications copyright 2021 AI Singapore
+# Modifications copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Original copyright (c) 2019 Zihao Zhang
+# Original copyright (c) 2019 Zihao Zhang
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 from typing import List, Dict, Tuple, Any
 import numpy as np

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import os
 import logging

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Yolo model with model types: v3 and v3tiny
+"""
 
 import os
 import logging

--- a/peekingduck/pipeline/nodes/node.py
+++ b/peekingduck/pipeline/nodes/node.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List

--- a/peekingduck/pipeline/nodes/node.py
+++ b/peekingduck/pipeline/nodes/node.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Abstract Node class for all nodes
+"""
+
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List

--- a/peekingduck/pipeline/nodes/node_template.py
+++ b/peekingduck/pipeline/nodes/node_template.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Node template for creating custom nodes
+"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/node_template.py
+++ b/peekingduck/pipeline/nodes/node_template.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode

--- a/peekingduck/pipeline/nodes/output/__init__.py
+++ b/peekingduck/pipeline/nodes/output/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Writes/displays the outputs of the pipeline.
+"""

--- a/peekingduck/pipeline/nodes/output/__init__.py
+++ b/peekingduck/pipeline/nodes/output/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -1,16 +1,16 @@
-"""Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License."""
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 from typing import Any, Dict

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Write the output image/video to file
+"""
+
 import os
 from typing import Any, Dict
 import numpy as np

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from typing import Any, Dict

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Show the outputs on your display
+"""
+
 import sys
 from typing import Any, Dict
 import cv2

--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Pipeline class that stores nodes and manages the data information used during inference
+"""
+
 import copy
 import textwrap
 from typing import List, Dict, Any

--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import copy
 import textwrap
 from typing import List, Dict, Any

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Main engine for Peekingduck processes
+"""
+
+
 import sys
 import logging
 from typing import List
@@ -20,10 +25,6 @@ from peekingduck.loaders import DeclarativeLoader
 from peekingduck.pipeline.nodes.node import AbstractNode
 
 END_TYPE = 'process_end'
-
-"""
-Combine runner at this level. Use this to create the graph, and waddle is loop or once
-"""
 
 
 class Runner():

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 import logging

--- a/peekingduck/utils/__init__.py
+++ b/peekingduck/utils/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Utility functions for PeekingDuck
+"""

--- a/peekingduck/utils/__init__.py
+++ b/peekingduck/utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/utils/graph_functions.py
+++ b/peekingduck/utils/graph_functions.py
@@ -1,18 +1,17 @@
-"""
-Copyright 2021 AI Singapore
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import os
 import logging

--- a/peekingduck/utils/graph_functions.py
+++ b/peekingduck/utils/graph_functions.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Utility functions for Tensorflow Graphed models
+"""
 
 import os
 import logging

--- a/peekingduck/utils/logger.py
+++ b/peekingduck/utils/logger.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 

--- a/peekingduck/utils/logger.py
+++ b/peekingduck/utils/logger.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Universal logging configueration
+"""
+
 import logging
 
 

--- a/peekingduck/weights_utils/__init__.py
+++ b/peekingduck/weights_utils/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Functions to help download model weights
+"""

--- a/peekingduck/weights_utils/__init__.py
+++ b/peekingduck/weights_utils/__init__.py
@@ -1,15 +1,13 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/peekingduck/weights_utils/checker.py
+++ b/peekingduck/weights_utils/checker.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Checks for model weights in weights folder
+"""
+
+
 import os
 from typing import List
 

--- a/peekingduck/weights_utils/checker.py
+++ b/peekingduck/weights_utils/checker.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 from typing import List
 

--- a/peekingduck/weights_utils/downloader.py
+++ b/peekingduck/weights_utils/downloader.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functions to download model weights
+"""
+
 import os
 import zipfile
 import requests
 from tqdm import tqdm
+
 
 BASE_URL = "https://peekingduck.blob.core.windows.net/models"
 

--- a/peekingduck/weights_utils/downloader.py
+++ b/peekingduck/weights_utils/downloader.py
@@ -1,18 +1,16 @@
-"""
-Copyright 2021 AI Singapore
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import zipfile


### PR DESCRIPTION
Changing license from strings to comments enables sphinx/autodocs to be better pick up the script docstrings instead of the license