### PR TITLE
Add "pipeline_end" attribute that can be used to execute tasks upon ending of pipeline.

### DIFF
--- a/peekingduck/configs/input/live.yml
+++ b/peekingduck/configs/input/live.yml
@@ -1,5 +1,5 @@
 input: ["source"]
-output: ["img","filename","fps"]
+output: ["img", "pipeline_end", "filename", "fps"]
 
 fps_saved_output_video: 10   #may need to change depending on user machine performance
 filename: webcamfeed.mp4

--- a/peekingduck/configs/input/recorded.yml
+++ b/peekingduck/configs/input/recorded.yml
@@ -1,5 +1,5 @@
 input: ["source"]
-output: ["img", "end", "filename", "fps"]
+output: ["img", "pipeline_end", "filename", "fps"]
 
 resize: {
             do_resizing: False,

--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -1,2 +1,2 @@
 input: ["img"]
-output: ["end"]
+output: ["pipeline_end"]

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -46,7 +46,7 @@ class Node(AbstractNode):
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         success, img = self.videocap.read_frame()  # type: ignore
-        
+
         if success:
             if self.resize_info['do_resizing']:
                 img = resize_image(img,
@@ -62,7 +62,6 @@ class Node(AbstractNode):
                         "filename": self.filename,
                         "fps": self.fps_saved_output_video}
             self.logger.warning("No video frames available for processing.")
-        
-        return outputs
 
+        return outputs
         

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -46,15 +46,23 @@ class Node(AbstractNode):
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         success, img = self.videocap.read_frame()  # type: ignore
+        
         if success:
             if self.resize_info['do_resizing']:
                 img = resize_image(img,
                                    self.resize_info['width'],
                                    self.resize_info['height'])
-            outputs = {
-                self.outputs[0]: img,
-                "fps": self.fps_saved_output_video,
-                "filename": self.filename}
-            return outputs
+            outputs = { "img": img,
+                        "pipeline_end": False,
+                        "filename": self.filename,
+                        "fps": self.fps_saved_output_video}
+        else:
+            outputs = { "img": None,
+                        "pipeline_end": True,
+                        "filename": self.filename,
+                        "fps": self.fps_saved_output_video}
+            self.logger.warning("No video frames available for processing.")
+        
+        return outputs
 
-        raise Exception("An issue has been encountered reading the Image")
+        

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -64,4 +64,3 @@ class Node(AbstractNode):
             self.logger.warning("No video frames available for processing.")
 
         return outputs
-        

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -32,6 +32,7 @@ class Node(AbstractNode):
         input_dir = config['input_dir']
         self.resize_info = config['resize']
         self._mirror_image = config['mirror_image']
+        self.file_end = False
 
         self._get_files(input_dir)
         self._get_next_input()
@@ -48,11 +49,11 @@ class Node(AbstractNode):
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         '''
         input: ["source"],
-        output: ["img", "end"]
+        output: ["img", "pipeline_end"]
         '''
         outputs = self._run_single_file()
 
-        if outputs["end"]:
+        if self.file_end:
             self._get_next_input()
             outputs = self._run_single_file()
 
@@ -61,19 +62,22 @@ class Node(AbstractNode):
     def _run_single_file(self) -> Dict[str, Any]:
         success, img = self.videocap.read_frame()  # type: ignore
 
+        self.file_end = True
         outputs = {"img": None,
-                   "end": True,
+                   "pipeline_end": True,
                    "filename": self._file_name,
                    "fps": self._fps}
         if success:
+            self.file_end = False
             if self.resize_info['do_resizing']:
                 img = resize_image(img,
                                    self.resize_info['width'],
                                    self.resize_info['height'])
             outputs = {"img": img,
-                       "end": False,
+                       "pipeline_end": False,
                        "filename": self._file_name,
                        "fps": self._fps}
+
         return outputs
 
     def _get_files(self, path: str) -> None:

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -22,7 +22,7 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.input.utils.preprocess import resize_image
 from peekingduck.pipeline.nodes.input.utils.read import VideoNoThread
 
-
+# pylint: disable=R0902
 class Node(AbstractNode):
     """Node to receive videos/image as inputs."""
 

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -16,7 +16,6 @@
 Show the outputs on your display
 """
 
-import sys
 from typing import Any, Dict
 import cv2
 from peekingduck.pipeline.nodes.node import AbstractNode
@@ -30,8 +29,8 @@ class Node(AbstractNode):
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         cv2.imshow('PeekingDuck', inputs["img"])
-        
+
         if cv2.waitKey(1) & 0xFF == ord('q'):
             return {"pipeline_end": True}
-            
+
         return {"pipeline_end": False}

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -29,7 +29,9 @@ class Node(AbstractNode):
         super().__init__(config, node_path=__name__)
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        cv2.imshow('livefeed', inputs[self.inputs[0]])
+        cv2.imshow('PeekingDuck', inputs["img"])
+        
         if cv2.waitKey(1) & 0xFF == ord('q'):
-            sys.exit(1)
-        return {}
+            return {"pipeline_end": True}
+            
+        return {"pipeline_end": False}

--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -35,17 +35,21 @@ class Pipeline:
         self.nodes = nodes
         self._check_pipe(nodes)
         self._data = {}  # type: ignore
-        self.video_end = False
+        self.terminate = False
 
     def __del__(self) -> None:
         for node in self.nodes:
             del node
 
     def execute(self) -> None:
-        """ executes all node contained within the pipe
+        """ executes all node contained within the pipeline
         """
-
         for node in self.nodes:
+            if "pipeline_end" in self._data and self._data["pipeline_end"]:  # type: ignore
+                self.terminate = True
+                if "pipeline_end" not in node.inputs:
+                    continue
+
             if "all" in node.inputs:
                 inputs = copy.deepcopy(self._data)
             else:
@@ -53,12 +57,8 @@ class Pipeline:
                           for key in node.inputs if key in self._data}
 
             outputs = node.run(inputs)
-
-            if 'end' in outputs and outputs['end']:  # type: ignore
-                self.video_end = True
-                break
-
             self._data.update(outputs)  # type: ignore
+
 
     def get_pipeline_results(self) -> Dict[str, Any]:
         """get all results data of nodes in pipeline

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -24,8 +24,6 @@ from peekingduck.pipeline.pipeline import Pipeline
 from peekingduck.loaders import DeclarativeLoader
 from peekingduck.pipeline.nodes.node import AbstractNode
 
-END_TYPE = 'process_end'
-
 
 class Runner():
     """Runner class that uses the declared nodes to create pipeline to run inference
@@ -63,7 +61,7 @@ class Runner():
     def run(self) -> None:
         """execute single or continuous inference
         """
-        while not self.pipeline.video_end:
+        while not self.pipeline.terminate:
             self.pipeline.execute()
         del self.pipeline
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -40,7 +40,7 @@ def config_node_input():
 @pytest.fixture
 def config_node_end():
     return {'input': ["test_output_1"],
-            'output': ["test_output_2", "end"]}
+            'output': ["test_output_2", "pipeline_end"]}
 
 
 @pytest.fixture
@@ -60,8 +60,9 @@ def pipeline_correct(test_input_node, test_node_end):
 
 class TestPipeline:
     def test_execute(self, pipeline_correct):
-        correct_data = {"test_output_1": "test_output_0"}
-
+        correct_data = {'test_output_1': 'test_output_0', 
+                        'test_output_2': 'test_output_0', 
+                        'pipeline_end': 'test_output_1'}
         pipeline_correct.execute()
 
         assert pipeline_correct._data == correct_data

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -141,7 +141,7 @@ class TestRunner:
 
             with pytest.raises(Exception):
 
-                runner_with_nodes.pipeline.video_end = False
+                runner_with_nodes.pipeline.terminate = False
                 runner_with_nodes.run()
 
         assert isinstance(runner_with_nodes.pipeline, object) == True
@@ -150,7 +150,7 @@ class TestRunner:
 
         assert isinstance(runner_with_nodes.pipeline, object) == True
 
-        runner_with_nodes.pipeline.video_end = True
+        runner_with_nodes.pipeline.terminate = True
 
         runner_with_nodes.run()
 


### PR DESCRIPTION
"pipeline_end" are the outputs of these 3 nodes. Usually set to `False`, but becomes `True` under these conditions:
1. In `input.recorded`, the last video file has been processed
2. In `input.live`, the live video gets interrupted, e.g. webcam removed
3. In `output.screen`, someone presses `q` to terminate the program

"pipeline_end" can be used as inputs in these nodes (some examples):
- Send a POST request to update that all videos have been processed
- Show the average FPS of the entire run on terminal
- Uploading all results somewhere when done

It's called `pipeline_end` instead of just `end`, to avoid confusing with `file_end` that lives locally within input.recorded that only checks if the video or image file has ended.

closes #242 