### PR TITLE
Unique custom folder name

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -19,11 +19,10 @@ import peekingduck.runner as pkd
 
 if __name__ == "__main__":
     RUN_PATH = os.path.join(os.getcwd(), 'PeekingDuck/run_config.yml')
-    CUSTOM_NODE_PATH = os.path.join(os.getcwd(), 'PeekingDuck/custom_nodes')
 
     setup_logger()
     logger = logging.getLogger(__name__)
     logger.info("Run path: %s", RUN_PATH)
 
-    runner = pkd.Runner(RUN_PATH, CUSTOM_NODE_PATH)
+    runner = pkd.Runner(RUN_PATH, "PeekingDuck")
     runner.run()

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -39,14 +39,14 @@ def _get_cwd() -> str:
     return os.getcwd()
 
 
-def create_custom_folder() -> None:
+def create_custom_folder(custom_folder_name: str) -> None:
     """Make custom nodes folder to create custom nodes
     """
     curdir = _get_cwd()
-    custom_node_dir = os.path.join(curdir, "src/custom_nodes")
+    custom_folder_dir = os.path.join(curdir, "src", custom_folder_name)
 
-    logger.info("Creating custom nodes folder in %s", custom_node_dir)
-    os.makedirs(custom_node_dir, exist_ok=True)
+    logger.info("Creating custom nodes folder in %s", custom_folder_dir)
+    os.makedirs(custom_folder_dir, exist_ok=True)
 
 
 def create_yml() -> None:
@@ -66,10 +66,11 @@ def create_yml() -> None:
 
 
 @cli.command()
-def init() -> None:
+@click.option('--custom_folder_name', default='custom_nodes')
+def init(custom_folder_name: str) -> None:
     """Initialise a PeekingDuck project"""
     print("Welcome to PeekingDuck!")
-    create_custom_folder()
+    create_custom_folder(custom_folder_name)
     create_yml()
 
 
@@ -84,7 +85,5 @@ def run(config_path: str) -> None:
     if not config_path:
         config_path = os.path.join(curdir, "run_config.yml")
 
-    custom_node_path = os.path.join(curdir, 'src/custom_nodes')
-
-    runner = Runner(config_path, custom_node_path)
+    runner = Runner(config_path, "src")
     runner.run()

--- a/peekingduck/loaders.py
+++ b/peekingduck/loaders.py
@@ -25,6 +25,8 @@ import yaml
 from peekingduck.pipeline.pipeline import Pipeline
 from peekingduck.pipeline.nodes.node import AbstractNode
 
+PEEKINGDUCK_NODE_TYPE = ["input", "model", "draw", "heuristic", "output"]
+
 
 class ConfigLoader:  # pylint: disable=too-few-public-methods
     """ Reads configuration and returns configuration required to
@@ -63,18 +65,23 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
 
     def __init__(self,
                  run_config: str,
-                 custom_folder_path: str = 'src/custom_nodes') -> None:
+                 custom_node_parent_folder: str) -> None:
         self.logger = logging.getLogger(__name__)
 
         pkdbasedir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-
         self.config_loader = ConfigLoader(pkdbasedir)
-        self.custom_config_loader = ConfigLoader(custom_folder_path)
-        self.node_list = self._load_node_list(run_config)
-        self.custom_folder_path = custom_folder_path
 
-        # add custom nodes path "src" for module discovery
-        sys.path.append(custom_folder_path.split("/")[-2])
+        self.node_list = self._load_node_list(run_config)
+
+        custom_folder = self._get_custom_name_from_node_list()
+        if custom_folder is not None:
+            custom_folder_path = os.path.join(os.getcwd(),
+                                              custom_node_parent_folder,
+                                              custom_folder)
+            self.custom_config_loader = ConfigLoader(custom_folder_path)
+            sys.path.append(custom_node_parent_folder)
+
+            self.custom_folder_path = custom_folder_path
 
     def _load_node_list(self, run_config: str) -> List[str]:
         """Loads a list of nodes from run_config.yml"""
@@ -83,6 +90,22 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
 
         self.logger.info('Successfully loaded run_config file.')
         return nodes
+
+    def _get_custom_name_from_node_list(self) -> Any:
+
+        custom_name = None
+
+        for node in self.node_list:
+            if isinstance(node, dict) is True:
+                node_type = [*node][0].split(".")[0]
+            else:
+                node_type = node.split(".")[0]
+
+            if node_type not in PEEKINGDUCK_NODE_TYPE:
+                custom_name = node_type
+                break
+
+        return custom_name
 
     def _instantiate_nodes(self) -> List[AbstractNode]:
         """ Given a list of imported nodes, instantiate nodes"""

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -32,12 +32,12 @@ class Runner():
     """Runner class that uses the declared nodes to create pipeline to run inference
     """
 
-    def __init__(self, RUN_PATH: str, CUSTOM_NODE_PATH: str = None,
+    def __init__(self, RUN_PATH: str, CUSTOM_NODE_PARENT_FOLDER: str = None,
                  nodes: List[AbstractNode] = None):
         """
         Args:
             RUN_PATH (str): path to yaml file of node pipeine declaration.
-            CUSTOM_NODE_PATH (str): path to custom nodes folder if used.
+            CUSTOM_NODE_PARENT_FOLDER (str): parent folder of the custom nodes folder.
             nodes (:obj:'list' of :obj:'Node'): if not using declarations via yaml,
                 initialize by giving the node stack as a list
 
@@ -49,7 +49,7 @@ class Runner():
 
             # create Graph to run
             self.node_loader = DeclarativeLoader(
-                RUN_PATH, CUSTOM_NODE_PATH)  # type: ignore
+                RUN_PATH, CUSTOM_NODE_PARENT_FOLDER)  # type: ignore
 
             self.pipeline = self.node_loader.get_pipeline()
 


### PR DESCRIPTION
This PR will provide the user with the flexibility to define their own name for their custom nodes folder. The technical approach is from the runconfig.yml, automatically pick up the custom node folder name. 

In addition, in the cli, option is provided to the user to define their own custom name or choose the default. 