### PR TITLE
Standardization of "end", "img" and "source" by replacing with "none"

### DIFF
--- a/peekingduck/configs/draw/bbox.yml
+++ b/peekingduck/configs/draw/bbox.yml
@@ -1,5 +1,5 @@
 input: ["bboxes", "img"]
-output: ["img"]
+output: ["none"]
 
 bbox_color: [255, 0, 255]
 bbox_thickness: 2

--- a/peekingduck/configs/draw/bbox_count.yml
+++ b/peekingduck/configs/draw/bbox_count.yml
@@ -1,2 +1,2 @@
 input: ["count", "img"]
-output: ["img"]
+output: ["none"]

--- a/peekingduck/configs/draw/btm_midpoint.yml
+++ b/peekingduck/configs/draw/btm_midpoint.yml
@@ -1,2 +1,2 @@
 input: ["btm_midpoint", "img"]
-output: ["img"]
+output: ["none"]

--- a/peekingduck/configs/draw/fps.yml
+++ b/peekingduck/configs/draw/fps.yml
@@ -1,2 +1,2 @@
 input: ["img"]
-output: ["img"]
+output: ["none"]

--- a/peekingduck/configs/draw/group_bbox_and_tag.yml
+++ b/peekingduck/configs/draw/group_bbox_and_tag.yml
@@ -1,5 +1,5 @@
 input: ["img", "bboxes", "obj_groups", "large_groups"]
-output: ["img"]
+output: ["none"]
 
 bbox_color: [0, 140, 255]
 bbox_thickness: 4

--- a/peekingduck/configs/draw/poses.yml
+++ b/peekingduck/configs/draw/poses.yml
@@ -1,5 +1,5 @@
 input: ["keypoints", "keypoint_scores", "keypoint_conns", "img"]
-output: ["img"]
+output: ["none"]
 
 keypoint_dot_color: [0, 255, 0]
 keypoint_dot_radius: 5

--- a/peekingduck/configs/draw/tag.yml
+++ b/peekingduck/configs/draw/tag.yml
@@ -1,4 +1,4 @@
 input: ["bboxes", "obj_tags", "img"]
-output: ["img"]
+output: ["none"]
 
 tag_color: [100, 0, 255]

--- a/peekingduck/configs/draw/zone_count.yml
+++ b/peekingduck/configs/draw/zone_count.yml
@@ -1,2 +1,2 @@
 input: ["zone_count", "img"]
-output: ["img"]
+output: ["none"]

--- a/peekingduck/configs/draw/zones.yml
+++ b/peekingduck/configs/draw/zones.yml
@@ -1,2 +1,2 @@
 input: ["zones", "img"]
-output: ["img"]
+output: ["none"]

--- a/peekingduck/configs/input/live.yml
+++ b/peekingduck/configs/input/live.yml
@@ -1,4 +1,4 @@
-input: ["source"]
+input: ["none"]
 output: ["img", "pipeline_end", "filename", "fps"]
 
 fps_saved_output_video: 10   #may need to change depending on user machine performance

--- a/peekingduck/configs/input/recorded.yml
+++ b/peekingduck/configs/input/recorded.yml
@@ -1,4 +1,4 @@
-input: ["source"]
+input: ["none"]
 output: ["img", "pipeline_end", "filename", "fps"]
 
 resize: {

--- a/peekingduck/configs/output/media_writer.yml
+++ b/peekingduck/configs/output/media_writer.yml
@@ -1,4 +1,4 @@
 input: ["img", "filename", "fps"]
-output: ["end"]
+output: ["none"]
 
 output_dir: 'PeekingDuck/data/output'

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -42,7 +42,7 @@ class Node(AbstractNode):
                 "large_groups".
 
         Returns:
-            outputs (dict): Dict with keys "img".
+            outputs (dict): Dict with keys "none".
         """
 
         group_bboxes = self._get_group_bbox_coords(

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -36,7 +36,7 @@ class Node(AbstractNode):
             inputs (dict): Dict with keys "bboxes", "obj_tags", "img".
 
         Returns:
-            outputs (dict): Dict with keys "img".
+            outputs (dict): Dict with keys "none".
         """
 
         draw_tags(inputs["img"], inputs["bboxes"],

--- a/peekingduck/pipeline/nodes/draw/zone_count.py
+++ b/peekingduck/pipeline/nodes/draw/zone_count.py
@@ -34,7 +34,7 @@ class Node(AbstractNode):
             inputs (dict): Dict with keys "btm_midpoint", "img".
 
         Returns:
-            outputs (dict): Dict with keys "img".
+            outputs (dict): Dict with keys "none".
         """
 
         draw_zone_count(inputs['img'], inputs['zone_count'])  # type: ignore

--- a/peekingduck/pipeline/nodes/draw/zones.py
+++ b/peekingduck/pipeline/nodes/draw/zones.py
@@ -34,7 +34,7 @@ class Node(AbstractNode):
             inputs (dict): Dict with keys "zones", "img".
 
         Returns:
-            outputs (dict): Dict with keys "img".
+            outputs (dict): Dict with keys "none".
         """
 
         draw_zones(inputs["img"], inputs["zones"])  # type: ignore

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         '''
-        input: ["source"],
+        input: ["none"],
         output: ["img", "pipeline_end"]
         '''
         outputs = self._run_single_file()

--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -76,7 +76,7 @@ class Pipeline:
 
         data_pool = []
 
-        if nodes[0].inputs[0] == 'source':
+        if nodes[0].inputs[0] == 'none':
             data_pool.extend(nodes[0].outputs)
 
         for node in nodes[1:]:

--- a/tests/pipeline/nodes/output/test_media_writer.py
+++ b/tests/pipeline/nodes/output/test_media_writer.py
@@ -31,7 +31,7 @@ def directory_contents():
 def writer():
     media_writer = Node({"output_dir": OUTPUT_PATH,
                          "input": "img",
-                         "output": "end"
+                         "output": "none"
                          })
     return media_writer
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -33,7 +33,7 @@ class MockedNode(AbstractNode):
 
 @pytest.fixture
 def config_node_input():
-    return {'input': ["source"],
+    return {'input': ["none"],
             'output': ["test_output_1"]}
 
 


### PR DESCRIPTION
A new ["none"] output/input type for nodes that don't take in any input/output:
1. output.media_writer will return ["none"] instead of ["end"]
2. All draw nodes will return ["none"] instead of ["img"]
3. input.live and input.recorded will take in ["none"] instead of ["source"] 

["none"] sounds consistent with our wildcard type ["all"].

Closes #66 and #179.