### PR TITLE
Fix unittest declarativeloader

### DIFF
--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -29,6 +29,7 @@ CUSTOM_NODE_TYPE = "custom_node_type"
 CUSTOM_NODE_NAME = "custom_node_name"
 CUSTOM_NODE = CUSTOM_NODE_TYPE + "." + CUSTOM_NODE_NAME
 NODES = {"nodes": [PKD_NODE,
+                   {PKD_NODE: [{'setting': True}]},
                    CUSTOM_NODE_NAME + "." + CUSTOM_NODE]}
 
 MODULE_PATH = "tmp_dir"
@@ -151,17 +152,22 @@ class TestDeclarativeLoader:
 
     def test_instantiate_nodes(self, declarativeloader):
 
-        pkd_node = ['peekingduck.pipeline.nodes.',
-                    PKD_NODE,
-                    declarativeloader.config_loader,
-                    None]
+        pkd_node_default = ['peekingduck.pipeline.nodes.',
+                            PKD_NODE,
+                            declarativeloader.config_loader,
+                            None]
+
+        pkd_node_edit = ['peekingduck.pipeline.nodes.',
+                         PKD_NODE,
+                         declarativeloader.config_loader,
+                         {'setting': True}]
 
         custom_node = [CUSTOM_NODE_NAME + ".",
                        CUSTOM_NODE,
                        declarativeloader.custom_config_loader,
                        None]
 
-        ground_truth = [pkd_node, custom_node]
+        ground_truth = [pkd_node_default, pkd_node_edit, custom_node]
 
         with mock.patch('peekingduck.loaders.DeclarativeLoader._init_node',
                         wraps=replace_init_node):

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -184,16 +184,21 @@ class TestDeclarativeLoader:
         path_to_node = ""
         node_name = PKD_NODE
         config_loader = declarativeloader.config_loader
-        config_updates = None
+        config_updates = {'setting': True}
 
-        init_node = declarativeloader._init_node(path_to_node,
-                                                 node_name,
-                                                 config_loader,
-                                                 config_updates)
+        with mock.patch('logging.Logger.warning') as mock_logger:
 
-        assert init_node._name == node_name
-        assert init_node._inputs == ['source']
-        assert init_node._outputs == ['end']
+            init_node = declarativeloader._init_node(path_to_node,
+                                                     node_name,
+                                                     config_loader,
+                                                     config_updates)
+
+            msg = "'setting' is not a valid configurable parameter"
+            mock_logger.assert_called_with(msg)
+
+            assert init_node._name == node_name
+            assert init_node._inputs == ['source']
+            assert init_node._outputs == ['end']
 
     def test_init_node_custom(self, declarativeloader):
 

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -22,14 +22,14 @@ import yaml
 import pytest
 from peekingduck.loaders import DeclarativeLoader
 
-PKD_NODE_TYPE = "pkd_node_type"
+PKD_NODE_TYPE = "input"
 PKD_NODE_NAME = "pkd_node_name"
-PKD_NODE = "pkd_node_type" + "." + "pkd_node_name"
+PKD_NODE = PKD_NODE_TYPE + "." + PKD_NODE_NAME
 CUSTOM_NODE_TYPE = "custom_node_type"
 CUSTOM_NODE_NAME = "custom_node_name"
-CUSTOM_NODE = "custom_node_type" + "." + "custom_node_name"
+CUSTOM_NODE = CUSTOM_NODE_TYPE + "." + CUSTOM_NODE_NAME
 NODES = {"nodes": [PKD_NODE,
-                   "custom_nodes." + CUSTOM_NODE]}
+                   CUSTOM_NODE_NAME + "." + CUSTOM_NODE]}
 
 MODULE_PATH = "tmp_dir"
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
@@ -98,7 +98,7 @@ def declarativeloader():
 
     setup()
 
-    declarative_loader = DeclarativeLoader(RUN_CONFIG_PATH, CUSTOM_FOLDER_PATH)
+    declarative_loader = DeclarativeLoader(RUN_CONFIG_PATH, MODULE_PATH)
 
     declarative_loader.config_loader._basedir = MODULE_PATH
     declarative_loader.custom_config_loader._basedir = CUSTOM_FOLDER_PATH
@@ -143,6 +143,10 @@ class TestDeclarativeLoader:
         for idx, node in enumerate(loaded_nodes):
             assert node == NODES["nodes"][idx]
 
+    def test_get_custom_name_from_node_list(self, declarativeloader):
+        custom_folder_name = declarativeloader._get_custom_name_from_node_list()
+        assert custom_folder_name == CUSTOM_NODE_NAME
+
     def test_instantiate_nodes(self, declarativeloader):
 
         pkd_node = ['peekingduck.pipeline.nodes.',
@@ -150,7 +154,7 @@ class TestDeclarativeLoader:
                     declarativeloader.config_loader,
                     None]
 
-        custom_node = ["custom_nodes.",
+        custom_node = [CUSTOM_NODE_NAME + ".",
                        CUSTOM_NODE,
                        declarativeloader.custom_config_loader,
                        None]
@@ -164,6 +168,7 @@ class TestDeclarativeLoader:
 
             for node_num, node in enumerate(instantiated_nodes):
                 for idx, output in enumerate(node):
+                    print(output)
                     assert output == ground_truth[node_num][idx]
 
     def test_init_node_pkd(self, declarativeloader):

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -26,17 +26,17 @@ from peekingduck.loaders import DeclarativeLoader
 
 PKD_NODE_TYPE = "input"
 PKD_NODE_NAME = "pkd_node_name"
-PKD_NODE = PKD_NODE_TYPE + "." + PKD_NODE_NAME
+PKD_NODE = f"{PKD_NODE_TYPE}.{PKD_NODE_NAME}"
 CUSTOM_NODE_TYPE = "custom_node_type"
 CUSTOM_NODE_NAME = "custom_node_name"
-CUSTOM_NODE = CUSTOM_NODE_TYPE + "." + CUSTOM_NODE_NAME
+CUSTOM_NODE = f"{CUSTOM_NODE_TYPE}.{CUSTOM_NODE_NAME}"
 NODES = {"nodes": [PKD_NODE,
                    {PKD_NODE: [{'setting': True}]},
-                   CUSTOM_NODE_NAME + "." + CUSTOM_NODE]}
+                   f"{CUSTOM_NODE_NAME}.{CUSTOM_NODE}"]}
 
 MODULE_PATH = "tmp_dir"
-UNIQUE_SUFFIX = '_'.join(random.choice(string.ascii_lowercase) for x in range(8))
-CUSTOM_FOLDER_NAME = "custom_nodes" + UNIQUE_SUFFIX
+UNIQUE_SUFFIX = ''.join(random.choice(string.ascii_lowercase) for x in range(8))
+CUSTOM_FOLDER_NAME = f"custom_nodes_{UNIQUE_SUFFIX}"
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
 CUSTOM_FOLDER_PATH = os.path.join(MODULE_PATH, CUSTOM_FOLDER_NAME)
 PKD_NODE_DIR = os.path.join(MODULE_PATH, PKD_NODE_TYPE)
@@ -54,7 +54,7 @@ def create_run_config_yaml(nodes):
 
 def create_node_python(node_dir, node_name):
 
-    node_file = node_name + ".py"
+    node_file = f"{node_name}.py"
     with open(os.path.join(node_dir, node_file), 'w') as fp:
         content = textwrap.dedent(
             """\
@@ -76,7 +76,8 @@ def create_node_config(config_dir, node_name):
                    "input": ["source"],
                    "output": ["end"]}
 
-    node_config_file = node_name + ".yml"
+    node_config_file = f"{node_name}.yml"
+
     with open(os.path.join(config_dir, node_config_file), 'w') as fp:
         yaml.dump(config_text, fp)
 
@@ -124,7 +125,7 @@ def replace_instantiate_nodes():
 
     node_path = PKD_NODE
     node_config_path = os.path.join(PKD_NODE_CONFIG_DIR,
-                                    PKD_NODE_NAME + ".yml")
+                                    f"{PKD_NODE_NAME}.yml")
 
     node = importlib.import_module(node_path)
     with open(node_config_path) as file:
@@ -166,7 +167,7 @@ class TestDeclarativeLoader:
                          declarativeloader.config_loader,
                          [{'setting': True}]]
 
-        custom_node = [CUSTOM_NODE_NAME + ".",
+        custom_node = [f"{CUSTOM_NODE_NAME}.",
                        CUSTOM_NODE,
                        declarativeloader.custom_config_loader,
                        None]
@@ -200,7 +201,7 @@ class TestDeclarativeLoader:
 
     def test_init_node_custom(self, declarativeloader):
 
-        path_to_node = CUSTOM_FOLDER_NAME + "."
+        path_to_node = f"{CUSTOM_FOLDER_NAME}."
         node_name = CUSTOM_NODE
         config_loader = declarativeloader.custom_config_loader
         config_updates = None
@@ -210,7 +211,7 @@ class TestDeclarativeLoader:
                                                  config_loader,
                                                  config_updates)
 
-        assert init_node._name == path_to_node + node_name
+        assert init_node._name == f"{path_to_node}{node_name}"
         assert init_node._inputs == ['source']
         assert init_node._outputs == ['end']
 

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -164,7 +164,7 @@ class TestDeclarativeLoader:
         pkd_node_edit = ['peekingduck.pipeline.nodes.',
                          PKD_NODE,
                          declarativeloader.config_loader,
-                         {'setting': True}]
+                         [{'setting': True}]]
 
         custom_node = [CUSTOM_NODE_NAME + ".",
                        CUSTOM_NODE,
@@ -187,21 +187,16 @@ class TestDeclarativeLoader:
         path_to_node = ""
         node_name = PKD_NODE
         config_loader = declarativeloader.config_loader
-        config_updates = {'setting': True}
+        config_updates = None
 
-        with mock.patch('logging.Logger.warning') as mock_logger:
+        init_node = declarativeloader._init_node(path_to_node,
+                                                 node_name,
+                                                 config_loader,
+                                                 config_updates)
 
-            init_node = declarativeloader._init_node(path_to_node,
-                                                     node_name,
-                                                     config_loader,
-                                                     config_updates)
-
-            msg = "'setting' is not a valid configurable parameter"
-            mock_logger.assert_called_with(msg)
-
-            assert init_node._name == node_name
-            assert init_node._inputs == ['source']
-            assert init_node._outputs == ['end']
+        assert init_node._name == node_name
+        assert init_node._inputs == ['source']
+        assert init_node._outputs == ['end']
 
     def test_init_node_custom(self, declarativeloader):
 

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -14,6 +14,8 @@
 
 import os
 import sys
+import string
+import random
 import importlib
 import textwrap
 from unittest import mock
@@ -33,8 +35,10 @@ NODES = {"nodes": [PKD_NODE,
                    CUSTOM_NODE_NAME + "." + CUSTOM_NODE]}
 
 MODULE_PATH = "tmp_dir"
+UNIQUE_SUFFIX = '_'.join(random.choice(string.ascii_lowercase) for x in range(8))
+CUSTOM_FOLDER_NAME = "custom_nodes" + UNIQUE_SUFFIX
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
-CUSTOM_FOLDER_PATH = os.path.join(MODULE_PATH, "custom_nodes")
+CUSTOM_FOLDER_PATH = os.path.join(MODULE_PATH, CUSTOM_FOLDER_NAME)
 PKD_NODE_DIR = os.path.join(MODULE_PATH, PKD_NODE_TYPE)
 CUSTOM_NODE_DIR = os.path.join(CUSTOM_FOLDER_PATH, CUSTOM_NODE_TYPE)
 PKD_NODE_CONFIG_DIR = os.path.join(MODULE_PATH, "configs", PKD_NODE_TYPE)
@@ -51,7 +55,7 @@ def create_run_config_yaml(nodes):
 def create_node_python(node_dir, node_name):
 
     node_file = node_name + ".py"
-    with open(os.path.join(node_dir,  node_file), 'w') as fp:
+    with open(os.path.join(node_dir, node_file), 'w') as fp:
         content = textwrap.dedent(
             """\
             from peekingduck.pipeline.nodes.node import AbstractNode
@@ -73,7 +77,7 @@ def create_node_config(config_dir, node_name):
                    "output": ["end"]}
 
     node_config_file = node_name + ".yml"
-    with open(os.path.join(config_dir,  node_config_file), 'w') as fp:
+    with open(os.path.join(config_dir, node_config_file), 'w') as fp:
         yaml.dump(config_text, fp)
 
 
@@ -176,7 +180,6 @@ class TestDeclarativeLoader:
 
             for node_num, node in enumerate(instantiated_nodes):
                 for idx, output in enumerate(node):
-                    print(output)
                     assert output == ground_truth[node_num][idx]
 
     def test_init_node_pkd(self, declarativeloader):
@@ -202,7 +205,7 @@ class TestDeclarativeLoader:
 
     def test_init_node_custom(self, declarativeloader):
 
-        path_to_node = "custom_nodes."
+        path_to_node = CUSTOM_FOLDER_NAME + "."
         node_name = CUSTOM_NODE
         config_loader = declarativeloader.custom_config_loader
         config_updates = None

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -144,7 +144,9 @@ class TestDeclarativeLoader:
             assert node == NODES["nodes"][idx]
 
     def test_get_custom_name_from_node_list(self, declarativeloader):
+
         custom_folder_name = declarativeloader._get_custom_name_from_node_list()
+
         assert custom_folder_name == CUSTOM_NODE_NAME
 
     def test_instantiate_nodes(self, declarativeloader):


### PR DESCRIPTION
This PR addresses the unit testing for Declarative Loader, specifically the way to locate custom folder name. 

In addition, more unit testing cases are also included to increase the coverage. 