### PR TITLE
ci(cicd-infra): add local test before build

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -7,8 +7,26 @@ on:
     types: published
 
 jobs:
+  local-install-test:
+    name: Build PeekingDuck and test locally
+    runs-on: ubuntu-18.04
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Update Version Number
+      run: |
+        bash ./scripts/update_version.sh $VERSION
+    - name: Local Test
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        bash ./scripts/run_tests.sh all
+        bash ./scripts/usecase_tests.sh
   build-publish-test:
     name: Build PeekingDuck on Test PyPI
+    needs: local-install-test
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
addresses first part of #252 which does a local installation and test before publishing is allowed.