### PR TITLE
Resolve incorrect approx_processed in logging

### DIFF
--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -33,7 +33,7 @@ class Node(AbstractNode):
         self.resize_info = config['resize']
         self._mirror_image = config['mirror_image']
         self.file_end = False
-        self.frame_counter = 0
+        self.frame_counter = -1
         self.tens_counter = 10
 
         self._get_files(input_dir)


### PR DESCRIPTION
This PR addresses the logging message of 10% approximate processing for images. 

In addition, as a further notice, when an image does not have a cv2.CAP_PROP_FRAME_COUNT value, it returns a sys.maxsize().

Closes #304 