### PR TITLE
Add feature to change node config from cli

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -24,5 +24,5 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.info("Run path: %s", RUN_PATH)
 
-    runner = pkd.Runner(RUN_PATH, "PeekingDuck")
+    runner = pkd.Runner(RUN_PATH, None, "PeekingDuck")
     runner.run()

--- a/__main__.py
+++ b/__main__.py
@@ -24,5 +24,5 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.info("Run path: %s", RUN_PATH)
 
-    runner = pkd.Runner(RUN_PATH, None, "PeekingDuck")
+    runner = pkd.Runner(RUN_PATH, "None", "PeekingDuck")
     runner.run()

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 @click.group()
 def cli() -> None:
     """
-    PeekingDuck is a python framework for dealing with Machine Learning model inferences.
+    PeekingDuck is a modular computer vision inference framework..
 
     Developed by Computer Vision Hub at AI Singapore.
     """
@@ -75,17 +75,21 @@ def init(custom_folder_name: str) -> None:
     create_custom_folder(custom_folder_name)
     create_yml()
 
+# peekingduck run --node_config input.live@'{"resize":{"do_resizing":True,"width":320}}' --node_config model.yolo@'{"yolo_score_threshold": 0.8}'
+
 
 @cli.command()
 @click.option('--config_path', default=None, type=click.Path(),
-
               help="List of nodes to run. None assumes \
                    run_config.yml at current working directory")
-def run(config_path: str) -> None:
+@click.option('--node_config', default=None, multiple=True, help="Modify node \
+                configurations in this format <node name>@'<dictionary of configs>'")
+def run(config_path: str, node_config: tuple) -> None:
     """Runs PeekingDuck"""
+
     curdir = _get_cwd()
     if not config_path:
         config_path = os.path.join(curdir, "run_config.yml")
 
-    runner = Runner(config_path, "src")
+    runner = Runner(config_path, node_config, "src")
     runner.run()

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -82,7 +82,7 @@ def init(custom_folder_name: str) -> None:
                    run_config.yml at current working directory")
 @click.option('--node_config', default="None",
               help="""Modify node configs by wrapping desired configs in a JSON string.\n
-                    Example: --node_config '{"node_name": {"param_1": val_1}}' """)
+                    Example: --node_config '{"node_name": {"param_1": var_1}}' """)
 def run(config_path: str, node_config: str) -> None:
     """Runs PeekingDuck"""
 

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -75,16 +75,15 @@ def init(custom_folder_name: str) -> None:
     create_custom_folder(custom_folder_name)
     create_yml()
 
-# peekingduck run --node_config input.live@'{"resize":{"do_resizing":True,"width":320}}' --node_config model.yolo@'{"yolo_score_threshold": 0.8}'
-
 
 @cli.command()
 @click.option('--config_path', default=None, type=click.Path(),
               help="List of nodes to run. None assumes \
                    run_config.yml at current working directory")
-@click.option('--node_config', default=None, multiple=True, help="Modify node \
-                configurations in this format <node name>@'<dictionary of configs>'")
-def run(config_path: str, node_config: tuple) -> None:
+@click.option('--node_config', default=None, help="Modify node \
+                configurations with by wrapping desired configs in a \
+                JSON string")
+def run(config_path: str, node_config: str) -> None:
     """Runs PeekingDuck"""
 
     curdir = _get_cwd()

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -81,7 +81,7 @@ def init(custom_folder_name: str) -> None:
               help="List of nodes to run. None assumes \
                    run_config.yml at current working directory")
 @click.option('--node_config', default="None", help="Modify node \
-                configurations with by wrapping desired configs in a \
+                configurations by wrapping desired configs in a \
                 JSON string")
 def run(config_path: str, node_config: str) -> None:
     """Runs PeekingDuck"""

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -80,7 +80,7 @@ def init(custom_folder_name: str) -> None:
 @click.option('--config_path', default=None, type=click.Path(),
               help="List of nodes to run. None assumes \
                    run_config.yml at current working directory")
-@click.option('--node_config', default=None, help="Modify node \
+@click.option('--node_config', default="None", help="Modify node \
                 configurations with by wrapping desired configs in a \
                 JSON string")
 def run(config_path: str, node_config: str) -> None:

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -80,9 +80,9 @@ def init(custom_folder_name: str) -> None:
 @click.option('--config_path', default=None, type=click.Path(),
               help="List of nodes to run. None assumes \
                    run_config.yml at current working directory")
-@click.option('--node_config', default="None", help="Modify node \
-                configurations by wrapping desired configs in a \
-                JSON string")
+@click.option('--node_config', default="None",
+              help="""Modify node configs by wrapping desired configs in a JSON string.\n
+                    Example: --node_config '{"node_name": {"param_1": val_1}}' """)
 def run(config_path: str, node_config: str) -> None:
     """Runs PeekingDuck"""
 

--- a/peekingduck/loaders.py
+++ b/peekingduck/loaders.py
@@ -69,7 +69,7 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
 
     def __init__(self,
                  run_config: str,
-                 config_updates_cli: tuple,
+                 config_updates_cli: str,
                  custom_node_parent_folder: str) -> None:
         self.logger = logging.getLogger(__name__)
 

--- a/peekingduck/loaders.py
+++ b/peekingduck/loaders.py
@@ -185,12 +185,12 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
             else:
                 if key not in dict_orig:
                     self.logger.warning(
-                        "Config for node %s does not have the key: %s.",
+                        "Config for node %s does not have the key: %s",
                         node_name, key)
                 else:
                     dict_orig[key] = value
                     self.logger.info(
-                        "Config for node %s is updated to: '%s': %s.",
+                        "Config for node %s is updated to: '%s': %s",
                         node_name, key, value)
         return dict_orig
 

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -29,11 +29,14 @@ class Runner():
     """Runner class that uses the declared nodes to create pipeline to run inference
     """
 
-    def __init__(self, RUN_PATH: str, CUSTOM_NODE_PARENT_FOLDER: str = None,
+    def __init__(self, RUN_PATH: str,
+                 config_updates_cli: tuple,
+                 CUSTOM_NODE_PARENT_FOLDER: str = None,
                  nodes: List[AbstractNode] = None):
         """
         Args:
             RUN_PATH (str): path to yaml file of node pipeine declaration.
+            config_updates_cli (tuple): strings defining node names and configs to update.
             CUSTOM_NODE_PARENT_FOLDER (str): parent folder of the custom nodes folder.
             nodes (:obj:'list' of :obj:'Node'): if not using declarations via yaml,
                 initialize by giving the node stack as a list
@@ -43,10 +46,9 @@ class Runner():
         self.logger = logging.getLogger(__name__)
 
         if not nodes:
-
             # create Graph to run
             self.node_loader = DeclarativeLoader(
-                RUN_PATH, CUSTOM_NODE_PARENT_FOLDER)  # type: ignore
+                RUN_PATH, config_updates_cli, CUSTOM_NODE_PARENT_FOLDER)  # type: ignore
 
             self.pipeline = self.node_loader.get_pipeline()
 

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -36,7 +36,7 @@ class Runner():
         """
         Args:
             RUN_PATH (str): path to yaml file of node pipeine declaration.
-            config_updates_cli (str): strings defining node names and configs to update.
+            config_updates_cli (str): stringified nested dictionaries of configs.
             CUSTOM_NODE_PARENT_FOLDER (str): parent folder of the custom nodes folder.
             nodes (:obj:'list' of :obj:'Node'): if not using declarations via yaml,
                 initialize by giving the node stack as a list

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -30,13 +30,13 @@ class Runner():
     """
 
     def __init__(self, RUN_PATH: str,
-                 config_updates_cli: tuple,
+                 config_updates_cli: str,
                  CUSTOM_NODE_PARENT_FOLDER: str = None,
                  nodes: List[AbstractNode] = None):
         """
         Args:
             RUN_PATH (str): path to yaml file of node pipeine declaration.
-            config_updates_cli (tuple): strings defining node names and configs to update.
+            config_updates_cli (str): strings defining node names and configs to update.
             CUSTOM_NODE_PARENT_FOLDER (str): parent folder of the custom nodes folder.
             nodes (:obj:'list' of :obj:'Node'): if not using declarations via yaml,
                 initialize by giving the node stack as a list

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -45,7 +45,7 @@ CUSTOM_NODE_DIR = os.path.join(CUSTOM_FOLDER_PATH, CUSTOM_NODE_TYPE)
 PKD_NODE_CONFIG_DIR = os.path.join(MODULE_PATH, "configs", PKD_NODE_TYPE)
 CUSTOM_NODE_CONFIG_DIR = os.path.join(
     CUSTOM_FOLDER_PATH, "configs", CUSTOM_NODE_TYPE)
-CONFIG_UPDATES_CLI = "{'input.live': {'resize':{'do_resizing':True, 'width':320}}, 'model.yolo': {'yolo_score_threshold': 0.8,'what':False}}"
+CONFIG_UPDATES_CLI = "{'input.live': {'resize':{'do_resizing':True, 'width':320}}}"
 
 
 def create_run_config_yaml(nodes):
@@ -245,7 +245,8 @@ class TestDeclarativeLoader:
                 'height': 720
             }}
         config_update = {'mirror_image': False,
-                         'resize': {'do_resizing': True}}
+                         'resize': {'do_resizing': True},
+                         'invalid_key': 123}
         ground_truth = {
             'mirror_image': False,
             'resize': {
@@ -262,6 +263,7 @@ class TestDeclarativeLoader:
         # Ensure that config_update does not replace the "resize" sub-dict completely and
         # erase "width" or "height"
         assert "width" in orig_config["resize"]
+        assert "invalid_key" not in ground_truth
 
     def test_get_pipeline(self, declarativeloader):
 

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -35,7 +35,8 @@ NODES = {"nodes": [PKD_NODE,
                    f"{CUSTOM_NODE_NAME}.{CUSTOM_NODE}"]}
 
 MODULE_PATH = "tmp_dir"
-UNIQUE_SUFFIX = ''.join(random.choice(string.ascii_lowercase) for x in range(8))
+UNIQUE_SUFFIX = ''.join(random.choice(string.ascii_lowercase)
+                        for x in range(8))
 CUSTOM_FOLDER_NAME = f"custom_nodes_{UNIQUE_SUFFIX}"
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
 CUSTOM_FOLDER_PATH = os.path.join(MODULE_PATH, CUSTOM_FOLDER_NAME)
@@ -233,6 +234,7 @@ class TestDeclarativeLoader:
 
     def test_edit_config(self, declarativeloader):
 
+        node_name = 'input.live'
         orig_config = {
             'mirror_image': True,
             'resize': {
@@ -251,7 +253,7 @@ class TestDeclarativeLoader:
             }}
 
         orig_config = declarativeloader._edit_config(
-            orig_config, config_update)
+            orig_config, config_update, node_name)
 
         assert orig_config['mirror_image'] == ground_truth['mirror_image']
         assert orig_config['resize']['do_resizing'] == ground_truth['resize']['do_resizing']

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -45,6 +45,7 @@ CUSTOM_NODE_DIR = os.path.join(CUSTOM_FOLDER_PATH, CUSTOM_NODE_TYPE)
 PKD_NODE_CONFIG_DIR = os.path.join(MODULE_PATH, "configs", PKD_NODE_TYPE)
 CUSTOM_NODE_CONFIG_DIR = os.path.join(
     CUSTOM_FOLDER_PATH, "configs", CUSTOM_NODE_TYPE)
+CONFIG_UPDATES_CLI = "{'input.live': {'resize':{'do_resizing':True, 'width':320}}, 'model.yolo': {'yolo_score_threshold': 0.8,'what':False}}"
 
 
 def create_run_config_yaml(nodes):
@@ -105,7 +106,8 @@ def declarativeloader():
 
     setup()
 
-    declarative_loader = DeclarativeLoader(RUN_CONFIG_PATH, MODULE_PATH)
+    declarative_loader = DeclarativeLoader(
+        RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, MODULE_PATH)
 
     declarative_loader.config_loader._basedir = MODULE_PATH
     declarative_loader.custom_config_loader._basedir = CUSTOM_FOLDER_PATH

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -31,6 +31,7 @@ MODULE_PATH = "tmp_dir"
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
 CUSTOM_FOLDER_PATH = os.path.join(MODULE_PATH, "custom_nodes")
 PKD_NODE_DIR = os.path.join(MODULE_PATH, PKD_NODE_TYPE)
+CONFIG_UPDATES_CLI = "{'input.live': {'resize':{'do_resizing':True}}}"
 
 
 class MockedNode(AbstractNode):
@@ -80,6 +81,7 @@ def runner():
                     wraps=replace_declarativeloader_get_pipeline):
 
         test_runner = Runner(RUN_CONFIG_PATH,
+                             CONFIG_UPDATES_CLI,
                              CUSTOM_FOLDER_PATH)
 
         return test_runner
@@ -102,6 +104,7 @@ def runner_with_nodes(test_input_node):
     instantiated_nodes = [test_input_node]
 
     test_runner = Runner(RUN_CONFIG_PATH,
+                         CONFIG_UPDATES_CLI,
                          CUSTOM_FOLDER_PATH,
                          instantiated_nodes)
 
@@ -122,7 +125,8 @@ class TestRunner:
 
             assert runner_with_nodes.pipeline.nodes[0]._name == PKD_NODE
             assert runner_with_nodes.pipeline.nodes[0]._inputs == ["source"]
-            assert runner_with_nodes.pipeline.nodes[0]._outputs == ["test_output_1"]
+            assert runner_with_nodes.pipeline.nodes[0]._outputs == [
+                "test_output_1"]
 
     def test_init_nodes_with_wrong_input(self):
 
@@ -132,7 +136,8 @@ class TestRunner:
                         side_effect=ValueError):
 
             with pytest.raises(SystemExit):
-                Runner(RUN_CONFIG_PATH, CUSTOM_FOLDER_PATH, [ground_truth])
+                Runner(RUN_CONFIG_PATH, CONFIG_UPDATES_CLI,
+                       CUSTOM_FOLDER_PATH, [ground_truth])
 
     def test_run(self, runner_with_nodes):
 


### PR DESCRIPTION
1. Command:
```
peekingduck run --node_config "{'input.live': {'resize':{'do_resizing':True, 'width':320}}, 'model.yolo': {'yolo_score_threshold': 0.8,'what':False}}"
```

2. Added logging to tell users which keys have been successfully updated and which are not:
```
2021-07-13T16:09:13 peekingduck.loaders INFO:Config for node model.yolo is updated to: 'yolo_score_threshold': 0.8
2021-07-13T16:09:13 peekingduck.loaders WARNING:Config for node model.yolo does not have the key: what
```

closes #258 