### PR TITLE
refactor(runner and pipeline): shift the running of the nodes from pipeline to runner 

### DIFF
--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -41,25 +41,6 @@ class Pipeline:
         for node in self.nodes:
             del node
 
-    def execute(self) -> None:
-        """ executes all node contained within the pipeline
-        """
-        for node in self.nodes:
-            if "pipeline_end" in self._data and self._data["pipeline_end"]:  # type: ignore
-                self.terminate = True
-                if "pipeline_end" not in node.inputs:
-                    continue
-
-            if "all" in node.inputs:
-                inputs = copy.deepcopy(self._data)
-            else:
-                inputs = {key: self._data[key]
-                          for key in node.inputs if key in self._data}
-
-            outputs = node.run(inputs)
-            self._data.update(outputs)  # type: ignore
-
-
     def get_pipeline_results(self) -> Dict[str, Any]:
         """get all results data of nodes in pipeline
 

--- a/peekingduck/pipeline/pipeline.py
+++ b/peekingduck/pipeline/pipeline.py
@@ -16,7 +16,6 @@
 Pipeline class that stores nodes and manages the data information used during inference
 """
 
-import copy
 import textwrap
 from typing import List, Dict, Any
 from peekingduck.pipeline.nodes.node import AbstractNode
@@ -34,7 +33,7 @@ class Pipeline:
         """
         self.nodes = nodes
         self._check_pipe(nodes)
-        self._data = {}  # type: ignore
+        self.data = {}  # type: ignore
         self.terminate = False
 
     def __del__(self) -> None:
@@ -47,7 +46,7 @@ class Pipeline:
         Returns:
             Dict[Any]: Dictionary of all pipeline node results
         """
-        return self._data
+        return self.data
 
     @staticmethod
     def _check_pipe(nodes: List[AbstractNode]) -> None:

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -65,19 +65,21 @@ class Runner():
         """
         while not self.pipeline.terminate:
             for node in self.pipeline.nodes:
-                if "pipeline_end" in self.pipeline._data and self.pipeline._data["pipeline_end"]:  # type: ignore
+                if "pipeline_end" in self.pipeline.data and \
+                        self.pipeline.data["pipeline_end"]:  # type: ignore
+                    
                     self.pipeline.terminate = True
                     if "pipeline_end" not in node.inputs:
                         continue
 
                 if "all" in node.inputs:
-                    inputs = copy.deepcopy(self.pipeline._data)
+                    inputs = copy.deepcopy(self.pipeline.data)
                 else:
-                    inputs = {key: self.pipeline._data[key]
-                            for key in node.inputs if key in self.pipeline._data}
+                    inputs = {key: self.pipeline.data[key]
+                            for key in node.inputs if key in self.pipeline.data}
 
                 outputs = node.run(inputs)
-                self.pipeline._data.update(outputs)  # type: ignore
+                self.pipeline.data.update(outputs)  # type: ignore
 
         del self.pipeline
 

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -67,7 +67,7 @@ class Runner():
             for node in self.pipeline.nodes:
                 if "pipeline_end" in self.pipeline.data and \
                         self.pipeline.data["pipeline_end"]:  # type: ignore
-                    
+         
                     self.pipeline.terminate = True
                     if "pipeline_end" not in node.inputs:
                         continue

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -67,7 +67,7 @@ class Runner():
             for node in self.pipeline.nodes:
                 if "pipeline_end" in self.pipeline.data and \
                         self.pipeline.data["pipeline_end"]:  # type: ignore
-         
+
                     self.pipeline.terminate = True
                     if "pipeline_end" not in node.inputs:
                         continue

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -59,14 +59,6 @@ def pipeline_correct(test_input_node, test_node_end):
 
 
 class TestPipeline:
-    def test_execute(self, pipeline_correct):
-        correct_data = {'test_output_1': 'test_output_0', 
-                        'test_output_2': 'test_output_0', 
-                        'pipeline_end': 'test_output_1'}
-        pipeline_correct.execute()
-
-        assert pipeline_correct._data == correct_data
-        assert pipeline_correct.get_pipeline_results() == correct_data
 
     def test_pipeline_wrong_order(self, test_input_node, test_node_end):
         with pytest.raises(ValueError):

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -25,7 +25,8 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 PKD_NODE_TYPE = "pkd_node_type"
 PKD_NODE_NAME = "pkd_node_name"
 PKD_NODE = "pkd_node_type" + "." + "pkd_node_name"
-NODES = {"nodes": [PKD_NODE]}
+PKD_NODE_2 = "pkd_node_type" + "." + "pkd_node_name" + "2"
+NODES = {"nodes": [PKD_NODE,PKD_NODE_2]}
 
 MODULE_PATH = "tmp_dir"
 RUN_CONFIG_PATH = os.path.join(MODULE_PATH, "run_config.yml")
@@ -90,18 +91,25 @@ def runner():
 @pytest.fixture
 def test_input_node():
 
-    config_node_input = {'input': ["source"],
+    config_node_input = {'input': ["none"],
                          'output': ["test_output_1"]}
 
     return MockedNode(config_node_input)
 
+@pytest.fixture
+def test_node_end():
+
+    config_node_end = {
+        'input': ["test_output_1"],
+        'output': ["test_output_2", "pipeline_end"]}
+    return MockedNode(config_node_end)
 
 @ pytest.fixture
-def runner_with_nodes(test_input_node):
+def runner_with_nodes(test_input_node, test_node_end):
 
     setup()
 
-    instantiated_nodes = [test_input_node]
+    instantiated_nodes = [test_input_node, test_node_end]
 
     test_runner = Runner(RUN_CONFIG_PATH,
                          CONFIG_UPDATES_CLI,
@@ -124,7 +132,7 @@ class TestRunner:
                         wraps=replace_pipeline_check_pipe):
 
             assert runner_with_nodes.pipeline.nodes[0]._name == PKD_NODE
-            assert runner_with_nodes.pipeline.nodes[0]._inputs == ["source"]
+            assert runner_with_nodes.pipeline.nodes[0]._inputs == ["none"]
             assert runner_with_nodes.pipeline.nodes[0]._outputs == [
                 "test_output_1"]
 
@@ -141,7 +149,7 @@ class TestRunner:
 
     def test_run(self, runner_with_nodes):
 
-        with mock.patch('peekingduck.pipeline.pipeline.Pipeline.execute',
+        with mock.patch('peekingduck.runner.Runner.run',
                         side_effect=Exception("End infinite while loop")):
 
             with pytest.raises(Exception):
@@ -150,6 +158,18 @@ class TestRunner:
                 runner_with_nodes.run()
 
         assert isinstance(runner_with_nodes.pipeline, object) == True
+
+    #Temporary commented as del self.pipeline in runner.run() delete pipeline
+    # def test_run_nodes(self, runner_with_nodes):
+        
+    #     correct_data = {'test_output_1': 'test_output_0', 
+    #                     'test_output_2': 'test_output_0', 
+    #                     'pipeline_end': 'test_output_1'}
+        
+    #     runner_with_nodes.run()
+
+    #     assert runner_with_nodes.pipeline._data == correct_data
+    #     assert runner_with_nodes.pipeline.get_pipeline_results() == correct_data
 
     def test_run_delete(self, runner_with_nodes):
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -168,7 +168,7 @@ class TestRunner:
         
     #     runner_with_nodes.run()
 
-    #     assert runner_with_nodes.pipeline._data == correct_data
+    #     assert runner_with_nodes.pipeline.data == correct_data
     #     assert runner_with_nodes.pipeline.get_pipeline_results() == correct_data
 
     def test_run_delete(self, runner_with_nodes):


### PR DESCRIPTION
Current implementation, peekingduck run the nodes in the Pipeline. Changes to be made to let Runner run the nodes, prepare for future implementation of different Runner mode (sequential and parallel)

Suggestion:
Shifting the the Pipeline.execute method to Runner.run. Then Pipeline will just contain the initiated nodes and also the data pool.

