### PR TITLE
update fps to saved_video_fps in live , recorded and media_writer nodes and config

### DIFF
--- a/peekingduck/configs/input/live.yml
+++ b/peekingduck/configs/input/live.yml
@@ -1,5 +1,5 @@
 input: ["none"]
-output: ["img", "pipeline_end", "filename", "fps"]
+output: ["img", "pipeline_end", "filename", "saved_video_fps"]
 
 fps_saved_output_video: 10   #may need to change depending on user machine performance
 filename: webcamfeed.mp4

--- a/peekingduck/configs/input/recorded.yml
+++ b/peekingduck/configs/input/recorded.yml
@@ -1,5 +1,5 @@
 input: ["none"]
-output: ["img", "pipeline_end", "filename", "fps"]
+output: ["img", "pipeline_end", "filename", "saved_video_fps"]
 
 resize: {
             do_resizing: False,

--- a/peekingduck/configs/output/media_writer.yml
+++ b/peekingduck/configs/output/media_writer.yml
@@ -1,4 +1,4 @@
-input: ["img", "filename", "fps"]
+input: ["img", "filename", "saved_video_fps"]
 output: ["none"]
 
 output_dir: 'PeekingDuck/data/output'

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -57,7 +57,7 @@ class Node(AbstractNode):
             outputs = { "img": img,
                         "pipeline_end": False,
                         "filename": self.filename,
-                        "fps": self.fps_saved_output_video}
+                        "saved_video_fps": self.fps_saved_output_video}
             self.frame_counter += 1
             if self.frame_counter%self.frames_log_freq == 0:
                 self.logger.info('Frames Processed: %s ...', self.frame_counter)
@@ -66,7 +66,7 @@ class Node(AbstractNode):
             outputs = { "img": None,
                         "pipeline_end": True,
                         "filename": self.filename,
-                        "fps": self.fps_saved_output_video}
+                        "saved_video_fps": self.fps_saved_output_video}
             self.logger.warning("No video frames available for processing.")
 
         return outputs

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -78,7 +78,7 @@ class Node(AbstractNode):
         outputs = {"img": None,
                    "pipeline_end": True,
                    "filename": self._file_name,
-                   "fps": self._fps}
+                   "saved_video_fps": self._fps}
         if success:
             self.file_end = False
             if self.resize_info['do_resizing']:
@@ -88,7 +88,7 @@ class Node(AbstractNode):
             outputs = {"img": img,
                        "pipeline_end": False,
                        "filename": self._file_name,
-                       "fps": self._fps}
+                       "saved_video_fps": self._fps}
 
         return outputs
 

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -59,7 +59,7 @@ class Node(AbstractNode):
         """ Writes media information to filepath
 
         Args:
-            inputs: ["filename", "img", "fps"]
+            inputs: ["filename", "img", "saved_video_fps"]
 
         Returns:
             outputs: [None]
@@ -68,12 +68,12 @@ class Node(AbstractNode):
         if not self._file_name:
             self._prepare_writer(inputs["filename"],
                                  inputs["img"],
-                                 inputs["fps"])
+                                 inputs["saved_video_fps"])
 
         if inputs["filename"] != self._file_name:
             self._prepare_writer(inputs["filename"],
                                  inputs["img"],
-                                 inputs["fps"])
+                                 inputs["saved_video_fps"])
 
         self._write(inputs["img"])
 
@@ -85,7 +85,7 @@ class Node(AbstractNode):
         else:
             self.writer.write(img)  # type: ignore
 
-    def _prepare_writer(self, filename: str, img: np.array, fps: int) -> None:
+    def _prepare_writer(self, filename: str, img: np.array, saved_video_fps: int) -> None:
 
         self._file_path_with_timestamp = self._append_datetime_filename(filename) #type: ignore
 
@@ -95,7 +95,7 @@ class Node(AbstractNode):
         else:
             resolution = img.shape[1], img.shape[0]
             self.writer = cv2.VideoWriter(
-                self._file_path_with_timestamp, self._fourcc, fps, resolution)
+                self._file_path_with_timestamp, self._fourcc, saved_video_fps, resolution)
 
     @staticmethod
     def _prepare_directory(output_dir) -> None:  # type: ignore

--- a/tests/pipeline/nodes/output/test_media_writer.py
+++ b/tests/pipeline/nodes/output/test_media_writer.py
@@ -47,7 +47,7 @@ class TestMediaWriter:
 
     def test_writer_writes_single_image(self, writer, create_image):
         image = create_image(size)
-        writer.run({"filename": "test.jpg", "img": image, "fps": 1})
+        writer.run({"filename": "test.jpg", "img": image, "saved_video_fps": 1})
         
         #pattern to check for time stamp filename_DDMMYY-hh-mm-ss.extension
         #approved extension = ["jpg", "jpeg", "png", "mp4", "avi", "mov", "mkv"]
@@ -62,9 +62,9 @@ class TestMediaWriter:
         image1 = create_image(size)
         image2 = create_image(size)
         image3 = create_image(size)
-        writer.run({"filename": "test1.jpg", "img": image1, "fps": 1})
-        writer.run({"filename": "test2.jpg", "img": image2, "fps": 1})
-        writer.run({"filename": "test3.jpg", "img": image3, "fps": 1})
+        writer.run({"filename": "test1.jpg", "img": image1, "saved_video_fps": 1})
+        writer.run({"filename": "test2.jpg", "img": image2, "saved_video_fps": 1})
+        writer.run({"filename": "test3.jpg", "img": image3, "saved_video_fps": 1})
 
         assert len(directory_contents()) == 3
 
@@ -80,7 +80,7 @@ class TestMediaWriter:
     def test_writer_writes_single_video(self, writer, create_video):
         video = create_video(size, nframes=20)
         for frame in video:
-            writer.run({"filename": "test.mp4", "img": frame, "fps": 30})
+            writer.run({"filename": "test.mp4", "img": frame, "saved_video_fps": 30})
 
         #pattern to check for time stamp filename_DDMMYY-hh-mm-ss.extension
         #approved extension = ["jpg", "jpeg", "png", "mp4", "avi", "mov", "mkv"]
@@ -95,10 +95,10 @@ class TestMediaWriter:
         video1 = create_video(size, nframes=20)
         video2 = create_video(size, nframes=20)
         for frame in video1:
-            writer.run({"filename": "test1.mp4", "img": frame, "fps": 10})
+            writer.run({"filename": "test1.mp4", "img": frame, "saved_video_fps": 10})
 
         for frame in video2:
-            writer.run({"filename": "test2.mp4", "img": frame, "fps": 10})
+            writer.run({"filename": "test2.mp4", "img": frame, "saved_video_fps": 10})
 
         assert len(directory_contents()) == 2
 


### PR DESCRIPTION
To clear any misunderstanding with another implementation of model fps where it is the fps of the processed frames.