### PR TITLE
docs (utils): correct arg description to match arg

### DIFF
--- a/peekingduck/weights_utils/downloader.py
+++ b/peekingduck/weights_utils/downloader.py
@@ -30,7 +30,7 @@ def download_weights(root: str, blob_file: str) -> None:
 
     Args:
         root (str): root directory of peekingduck
-        url (str): url to download weights from
+        blob_file (str): name of file to be downloaded
     """
 
     extract_dir = os.path.join(root, "..", "weights")


### PR DESCRIPTION
The arg description (i.e. url) did not seem to match the name of the arg (i.e. blob file). Made minor corrections to correct it.