### PR TITLE
Bbox colours

### DIFF
--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -29,9 +29,6 @@ class Node(AbstractNode):
         self.show_labels = config['show_labels']
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        if self.show_labels:
-            draw_bboxes(inputs["img"], inputs["bboxes"],
-                        CHAMPAGNE, inputs["bbox_labels"])  # type: ignore
-        else:
-            draw_bboxes(inputs["img"], inputs["bboxes"], CHAMPAGNE)  # type: ignore
+        draw_bboxes(inputs["img"], inputs["bboxes"],
+                    inputs["bbox_labels"], self.show_labels)  # type: ignore
         return {}

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -18,7 +18,6 @@ Draw bounding boxes over detected object
 from typing import Any, Dict
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.nodes.draw.utils.bbox import draw_bboxes
-from peekingduck.pipeline.nodes.draw.utils.constants import CHAMPAGNE
 
 
 class Node(AbstractNode):

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -51,7 +51,8 @@ class Node(AbstractNode):
         group_tags = self._get_group_tags(
             inputs["large_groups"], self.tag)
 
-        draw_bboxes(inputs["img"], group_bboxes, TOMATO)   # type: ignore
+        # show labels set to False to reduce clutter on display
+        draw_bboxes(inputs["img"], group_bboxes, TOMATO, False)   # type: ignore
         draw_tags(inputs["img"], group_bboxes, group_tags, TOMATO)  # type: ignore
 
         return {}

--- a/peekingduck/pipeline/nodes/draw/utils/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/utils/bbox.py
@@ -22,15 +22,16 @@ import numpy as np
 import cv2
 from cv2 import FONT_HERSHEY_SIMPLEX, LINE_AA
 from peekingduck.pipeline.nodes.draw.utils.constants import \
-    CHAMPAGNE, BLACK, THICK, VERY_THICK, NORMAL_FONTSCALE, POINT_RADIUS, FILLED
+    CHAMPAGNE, BLACK, THICK, VERY_THICK, NORMAL_FONTSCALE, \
+    POINT_RADIUS, FILLED, PRIMARY_PALETTE, PRIMARY_PALETTE_LENGTH as TOTAL_COLOURS
 from peekingduck.pipeline.nodes.draw.utils.general import \
     get_image_size, project_points_onto_original_image
 
 
 def draw_bboxes(frame: np.array,
                 bboxes: List[List[float]],
-                colour: Tuple[int, int, int],
-                bbox_labels: List[str] = None) -> None:
+                bbox_labels: List[str],
+                show_labels: bool) -> None:
     """Draw bboxes onto an image frame.
 
     Args:
@@ -40,10 +41,14 @@ def draw_bboxes(frame: np.array,
         bbox_labels (List[str]): labels of object detected
     """
     image_size = get_image_size(frame)
+    # Get unique label colour indexes
+    colour_indx = {label: indx for indx, label in enumerate(set(bbox_labels))}
 
     for i, bbox in enumerate(bboxes):
-        if bbox_labels is not None:
-            _draw_bbox(frame, bbox, image_size, colour, bbox_labels[i])
+        colour = PRIMARY_PALETTE[colour_indx[bbox_labels[i]] % TOTAL_COLOURS]
+        if show_labels:
+            _draw_bbox(frame, bbox, image_size,
+                       colour, bbox_labels[i])
         else:
             _draw_bbox(frame, bbox, image_size, colour)
 


### PR DESCRIPTION
Added unique colours for different objects that were detected. Note that bbox labels and show labels are made compulsory to accommodate the use of the labels to get the colour of each bbox. As such, minor changes are also made to group and tag to match these changes.