### PR TITLE
test(cicd): include links with # in it

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -51,7 +51,7 @@ def check_files(lst_filepaths):
             ]
             total_list_of_links = img_links + href_links
             final_list_of_links = [txt for txt in total_list_of_links if ("." in txt)]
-            # to extract the link from txt such as [here](./io_draw_nodes.md#input-nodes)
+            # to extract the valid link from some links such as [here](./io_draw_nodes.md#input-nodes)
             final_list_of_links = [link.split("#")[0] for link in final_list_of_links]
 
         for link in final_list_of_links:

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -50,9 +50,9 @@ def check_files(lst_filepaths):
                 tag["href"] for tag in filtered_by_href_tags if tag.has_attr("href")
             ]
             total_list_of_links = img_links + href_links
-            final_list_of_links = [
-                txt for txt in total_list_of_links if ("." in txt) and ("#" not in txt)
-            ]  # remove leftover artifacts
+            final_list_of_links = [txt for txt in total_list_of_links if ("." in txt)]
+            # to extract the link from txt such as [here](./io_draw_nodes.md#input-nodes)
+            final_list_of_links = [link.split("#")[0] for link in final_list_of_links]
 
         for link in final_list_of_links:
             # if link is a https link, run request.urlopen

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -51,7 +51,7 @@ def check_files(lst_filepaths):
             ]
             total_list_of_links = img_links + href_links
             final_list_of_links = [txt for txt in total_list_of_links if ("." in txt)]
-            # to extract the valid link from some links such as [here](./io_draw_nodes.md#input-nodes)
+            # to extract the valid link from some links such as ./io_draw_nodes.md#input-nodes
             final_list_of_links = [link.split("#")[0] for link in final_list_of_links]
 
         for link in final_list_of_links:


### PR DESCRIPTION
There are some links with # in the html for it to reference another part of the html. 

Example `[here](./io_draw_nodes.md#input-nodes)` , where `./io_draw_nodes.md` is deprecated. 

An update is made to catch this type of links and check if it is valid.