### PR TITLE
Revert previous commit to change yolo test fixture

### DIFF
--- a/.github/workflows/post_merge_checks.yml
+++ b/.github/workflows/post_merge_checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-18.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, windows-2019]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-18.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ import pytest
 
 import cv2
 
-TEST_HUMAN_IMAGES = ['t1.jpg', 't4.jpg', 't2.jpg']
+TEST_HUMAN_IMAGES = ['t1.jpg', 't2.jpg', 't4.jpg']
 TEST_NO_HUMAN_IMAGES = ['black.jpg', 't3.jpg']
 PKD_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), '..', 'peekingduck'

--- a/tests/pipeline/nodes/model/yolov4/test_yolo.py
+++ b/tests/pipeline/nodes/model/yolov4/test_yolo.py
@@ -21,37 +21,10 @@ import numpy.testing as npt
 import cv2
 import tensorflow as tf
 from unittest import mock, TestCase
-from pathlib import Path
 from peekingduck.pipeline.nodes.model.yolo import Node
 from peekingduck.pipeline.nodes.model.yolov4.yolo_files.detector import Detector
 from peekingduck.pipeline.nodes.model.yolov4.yolo_files.models import yolov3, yolov3_tiny
 
-
-# Yolo model has some issue(Windows fatal exception) with pytest on Github actions
-# that limits the number of image tested to 2 for windows (Windows server 2019 and 2016),
-# no issue with linux (ubuntu). No issue when pytest run locally on Windows
-# Only for yolo_test, use the test_human_images_yolo and test_no_human_images_yolo
-# For other model's unit test use the test_human_images and test_no_human_images
-# in conftest.py
-
-TEST_HUMAN_IMAGES_YOLO = ['t1.jpg']
-TEST_NO_HUMAN_IMAGES_YOLO = ['black.jpg']
-PKD_DIR = os.path.join(
-    Path(__file__).parents[4]
-)# path to reach 5 file levels up from yolo_test.py
-
-@pytest.fixture(params=TEST_HUMAN_IMAGES_YOLO)
-def test_human_images_yolo(request):
-    test_img_dir = os.path.join(PKD_DIR, '..', 'images', 'testing')
-
-    yield os.path.join(test_img_dir, request.param)
-
-
-@pytest.fixture(params=TEST_NO_HUMAN_IMAGES_YOLO)
-def test_no_human_images_yolo(request):
-    test_img_dir = os.path.join(PKD_DIR, '..', 'images', 'testing')
-
-    yield os.path.join(test_img_dir, request.param)
 
 @pytest.fixture
 def yolo_config():
@@ -86,8 +59,8 @@ def replace_download_weights(root, blob_file):
 @pytest.mark.mlmodel
 class TestYolo:
 
-    def test_no_human_image(self, test_no_human_images_yolo, yolo):
-        blank_image = cv2.imread(test_no_human_images_yolo)
+    def test_no_human_image(self, test_no_human_images, yolo):
+        blank_image = cv2.imread(test_no_human_images)
         output = yolo.run({'img': blank_image})
         expected_output = {'bboxes': np.empty((0, 4), dtype=np.float32),
                            'bbox_labels': np.empty((0)),
@@ -97,8 +70,8 @@ class TestYolo:
         npt.assert_equal(output['bbox_labels'], expected_output['bbox_labels'])
         npt.assert_equal(output['bbox_scores'], expected_output['bbox_scores'])        
 
-    def test_return_at_least_one_person_and_one_bbox(self, test_human_images_yolo, yolo):
-        test_img = cv2.imread(test_human_images_yolo)
+    def test_return_at_least_one_person_and_one_bbox(self, test_human_images, yolo):
+        test_img = cv2.imread(test_human_images)
         output = yolo.run({'img': test_img})
         assert 'bboxes' in output
         assert output['bboxes'].size != 0


### PR DESCRIPTION
Revert the previous commit  48aa098 in #378 

In github actions, windows 2016/2019 sometimes causes the post merge checks to fail. Currently do not have any idea what is causing the failure. 

Decision is to remove the windows check and also revert the changes made to the test fixtures in test_yolo in #378 

Future investigation on the root cause of Windows failure required before reinstating windows in the pre/post merge checks