### PR TITLE
docs(RTD): clarified some parts in the RTD documentation

### DIFF
--- a/docs/source/getting_started/02_configure_pkdk.md
+++ b/docs/source/getting_started/02_configure_pkdk.md
@@ -62,20 +62,24 @@ By default, `model.yolo` detects humans. We can change its behavior either by 1)
 1. From the default `run_config.yml`, update the nodes accordingly:
   ```yaml
     nodes:
-    - input.live
+    - input.recorded
     - model.yolo
     - draw.bbox
     - output.screen
+    - output.media_writer
   ```
 2. Run PeekingDuck with `--node_config` and the new configurations in a JSON-like structure:
  ```bash
- peekingduck run --node_config "{'input.live': {'input_dir': <directory where videos/images are stored}, \
+ peekingduck run --node_config "{'input.recorded': {'input_dir': '<directory where videos/images are stored>'}, \
                                  'model.yolo': {'detect_ids': [14]}, \
-                                 'output.media_writer': {'output_dir': <directory to save results>}}"
+                                 'output.media_writer': {'output_dir': '<directory to save results>'}}"
  ```
 
   Notice that the configs are structured in a {<node_name>: {<param_name>:<param_value>}} format.
+  Note that for the `'<directory/filepath>'` do encase in apostrophe.
+  For windows users, do use `\\` in the directory/filepath when keyed in CLI
 
+For new configurations updates through CLI, updates can only be done for nodes that have been declared in `run_config.yml`. It is curently not possible to insert new nodes via `--node_config` in CLI
 
 Regardless of the method you choose to configure PeekingDuck, the processed files will be saved to the specified output directory once PeekingDuck is finished running. You should get this in your output file:
 

--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -70,7 +70,7 @@ period: 1                       # time interval (s) between logs
 filepath: 'results/stats.csv'   # output file location
 ```
 
-Do note that in this example, `<results>` directory is created and PeekingDuck will the csv as `stats.csv` in the directory.
+Do note that in this example, `<results>` directory is created and PeekingDuck will save the csv as `stats.csv` in the directory.
 Node configs contains information on the input and outputs for PeekingDuck to manage.
 We recommend new users to use the [config template](https://github.com/aimakerspace/PeekingDuck/blob/dev/peekingduck/configs/node_template.yml) for reference.
 

--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -70,6 +70,7 @@ period: 1                       # time interval (s) between logs
 filepath: 'results/stats.csv'   # output file location
 ```
 
+Do note that in this example, `<results>` directory is created and PeekingDuck will the csv as `stats.csv` in the directory.
 Node configs contains information on the input and outputs for PeekingDuck to manage.
 We recommend new users to use the [config template](https://github.com/aimakerspace/PeekingDuck/blob/dev/peekingduck/configs/node_template.yml) for reference.
 

--- a/docs/source/getting_started/04_python_mode.md
+++ b/docs/source/getting_started/04_python_mode.md
@@ -26,10 +26,10 @@ from peekingduck.pipeline.nodes.draw import bbox
 from peekingduck.pipeline.nodes.output import media_writer
 
 # Initialise the nodes
-input_node = recorded.Node(input_dir="data/input/t1.jpg")
+input_node = recorded.Node(input_dir="<directory>")
 yolo_node = yolo.Node()
 draw_node = bbox.Node()
-output_node = media_writer.Node(output_dir="data/output")
+output_node = media_writer.Node(output_dir="<directory>")
 
 # Run it in the runner
 runner = Runner(nodes=[input_node, yolo_node, draw_node, output_node])


### PR DESCRIPTION
I have noticed some errors in the RTD guide and also some areas that require more clarification for the benefit of readers.

In the Getting Started > Changing Nodes and Settings > Configuring node behaviour > via CLI section:
- The guide suggested `input.live  : {'input_dir': <directory where videos/images are stored}`. 
- Input live node do not have input dir argument. should be replaced with input.recorded. 
- Also for the directory/filepath need to high light to be in apostrophe `  {'input.recorded'  : {'input_dir': '<directory where videos/images are stored>'}}`
- When testing in windows need to suggest to use `\\` rather than single `\` in the filepath 
- The example run_config.yml did not use output.media_writer but the `--node_config` example used it 
- Should highlight that updates using `--node_config` in CLI can only update configs for nodes declared in run_config.yml

In the Getting Started >Building Custom Nodes to run with PeekingDuck>Step 3: Create Node Configs section:
- the file path for the `<node>.yml` example should use `filepath: '<filepath>.csv' ` as the user may not have created a `<results>` file dir
- using `filepath: 'results/stats.csv' ` without creating `<results>` file dir will raise a file do not exist error

In the Getting Started >PeekingDuck Python API>Sample Code section:
- similiar to the above issue raise, `input_node = recorded.Node(input_dir="data/input/t1.jpg")` and `output_node = media_writer.Node(output_dir="data/output")` should state `input_node = recorded.Node(input_dir="<file path>")` and `output_node = media_writer.Node(output_dir="<filepath>")`
- so as to avoid any error due to filepath to not exist if user copy the code as it is in the guide

For #377 