### PR TITLE
upload files for TensorRT and TF-TRT for yolo LP

### DIFF
--- a/peekingduck/configs/model/tensorRT.yml
+++ b/peekingduck/configs/model/tensorRT.yml
@@ -1,0 +1,25 @@
+input: ["img"]
+output: ["bboxes", "bbox_labels", "bbox_scores"]
+
+yolo_plugin_path: "/home/aisg/Cvhub/tensorrt_demo/tensorrt_demos/plugins/libyolo_layer.so"
+
+model_type: v4 # v4 or v4tiny
+model_weights_dir: {
+    v4: "../weights/yolo_license_plate/LPyolov4",
+    v4tiny: "../weights/yolo_license_plate/LPyolov4tiny",
+}
+TensorRT_path: {
+    v4: "/home/aisg/Cvhub/tensorrt_demo/tensorrt_demos/yolo/yolov4-LP.trt",
+    v4tiny: "/home/aisg/Cvhub/tensorrt_demo/tensorrt_demos/yolo/yolov4tiny-LP.trt",
+}
+
+converted_model_path: {
+    v4: "../weights/TRTv4",
+    v4tiny: "../weights/TRTv4tiny",
+}
+    
+size: 416
+max_output_size_per_class: 50
+max_total_size: 50
+yolo_score_threshold: 0.1
+yolo_iou_threshold: 0.3

--- a/peekingduck/configs/model/yolo_TF_TRT.yml
+++ b/peekingduck/configs/model/yolo_TF_TRT.yml
@@ -1,0 +1,20 @@
+input: ["img"]
+output: ["bboxes", "bbox_labels", "bbox_scores"]
+
+
+model_type: v4 # v4 or v4tiny
+model_weights_dir: {
+    v4: "../weights/yolo_license_plate/LPyolov4",
+    v4tiny: "../weights/yolo_license_plate/LPyolov4tiny",
+}
+
+converted_model_path: {
+    v4: "../weights/TRTv4",
+    v4tiny: "../weights/TRTv4tiny",
+}
+    
+size: 416
+max_output_size_per_class: 50
+max_total_size: 50
+yolo_score_threshold: 0.1
+yolo_iou_threshold: 0.3

--- a/peekingduck/pipeline/nodes/model/tensorRT.py
+++ b/peekingduck/pipeline/nodes/model/tensorRT.py
@@ -1,0 +1,71 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Draw bounding boxes over detected object
+"""
+
+from typing import Any, Dict
+from peekingduck.pipeline.nodes.node import AbstractNode
+from peekingduck.pipeline.nodes.model.tensorRTv1.detector import Detector
+
+
+class Node(AbstractNode):
+    """Draw bounding boxes on image.
+
+    The draw bbox node uses the bboxes and, optionally, the bbox labels from the model
+    predictions to draw the bbox predictions onto the image.
+    For better understanding of the usecase, refer to the
+    `object counting usecase <use_cases/object_counting.html>`_.
+
+    Inputs:
+
+        |img|
+
+        |bboxes|
+
+        |bbox_labels|
+
+    Outputs:
+        |none|
+
+    Configs:
+        show_labels (:obj:`bool`): **default = False**
+            Show class label, e.g. "person", above bounding box
+    """
+
+    def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
+        super().__init__(config, node_path=__name__, **kwargs)
+        self.model = Detector(self.config)
+
+
+    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Function that reads the image input and returns the bboxes
+        of the specified objects chosen to be detected
+
+        Args:
+            inputs (Dict): Dictionary of inputs with key "img"
+        Returns:
+            outputs (Dict): bbox output in dictionary format with keys
+            "bboxes", "bbox_labels" and "bbox_scores"
+        """
+
+        bboxes, labels, scores = self.model.predict(inputs["img"])
+        outputs = {
+            "bboxes": bboxes,
+            "bbox_labels": labels,
+            "bbox_scores": scores,
+        }
+
+        return outputs

--- a/peekingduck/pipeline/nodes/model/tensorRTv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/tensorRTv1/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Yolo-related files for TensorRT yolo node
+"""

--- a/peekingduck/pipeline/nodes/model/tensorRTv1/detector.py
+++ b/peekingduck/pipeline/nodes/model/tensorRTv1/detector.py
@@ -1,0 +1,274 @@
+"""yolo_with_plugins.py
+
+Implementation of TrtYOLO class with the yolo_layer plugins.
+"""
+
+
+# from __future__ import print_function
+
+import ctypes
+
+import time
+
+import os
+import logging
+from typing import Dict, Any, List, Tuple
+import numpy as np
+import cv2
+import tensorflow as tf
+import tensorrt as trt
+import pycuda.driver as cuda
+import pycuda.autoinit
+from tensorflow.python.compiler.tensorrt import trt_convert
+from tensorflow.python.saved_model import tag_constants
+
+
+class HostDeviceMem(object):
+    """Simple helper data class that's a little nicer to use than a 2-tuple."""
+    def __init__(self, host_mem, device_mem):
+        self.host = host_mem
+        self.device = device_mem
+
+    def __str__(self):
+        return "Host:\n" + str(self.host) + "\nDevice:\n" + str(self.device)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class Detector:
+
+    def __init__(self, config: Dict[str, Any], cuda_ctx=None) -> None:
+        
+        self.config = config
+        self.root_dit = config["root"]
+        # self.logger = logging.getLogger(__name__)
+        self.model_type = config["model_type"]
+        self.trt_logger = trt.Logger(trt.Logger.INFO)
+        self.cuda_ctx = cuda_ctx
+        if self.cuda_ctx:
+            self.cuda_ctx.push()
+
+        try:
+            ctypes.cdll.LoadLibrary(self.config["yolo_plugin_path"])
+        except OSError as e:
+            raise SystemExit('ERROR: failed to load ./plugins/libyolo_layer.so.  '
+                            'Did you forget to do a "make" in the "./plugins/" '
+                            'subdirectory?') from e
+
+        self.engine = self._load_engine()
+        self.input_shape = self.get_input_shape(self.engine)
+        
+        try:
+            self.context = self.engine.create_execution_context()
+            # self.inputs, self.outputs, self.bindings, self.stream = \
+            #     self.allocate_buffers()
+        except Exception as e:
+            raise RuntimeError('fail to allocate CUDA resources') from e
+        finally:
+            if self.cuda_ctx:
+                self.cuda_ctx.pop()
+
+    def _load_engine(self) -> Any:
+        TRTbin = self.config["TensorRT_path"][self.config["model_type"]]
+        with open(TRTbin, 'rb') as f, trt.Runtime(self.trt_logger) as runtime:
+            return runtime.deserialize_cuda_engine(f.read())
+
+    
+    def allocate_buffers(self) -> Tuple[List,List,List,Any]:
+        """Allocates all host/device in/out buffers required for an engine."""
+        inputs = []
+        outputs = []
+        bindings = []
+        output_idx = 0
+        stream = cuda.Stream()
+        for binding in self.engine:
+            binding_dims = self.engine.get_binding_shape(binding)
+            if len(binding_dims) == 4:
+                # explicit batch case (TensorRT 7+)
+                size = trt.volume(binding_dims)
+            elif len(binding_dims) == 3:
+                # implicit batch case (TensorRT 6 or older)
+                size = trt.volume(binding_dims) * self.engine.max_batch_size
+            else:
+                raise ValueError('bad dims of binding %s: %s' % (binding, str(binding_dims)))
+            dtype = trt.nptype(self.engine.get_binding_dtype(binding))
+            # Allocate host and device buffers
+            host_mem = cuda.pagelocked_empty(size, dtype)
+            device_mem = cuda.mem_alloc(host_mem.nbytes)
+            # Append the device buffer to device bindings.
+            bindings.append(int(device_mem))
+            # Append to the appropriate list.
+            if self.engine.binding_is_input(binding):
+                inputs.append(HostDeviceMem(host_mem, device_mem))
+            else:
+                # each grid has 3 anchors, each anchor generates a detection
+                # output of 7 float32 values
+                assert size % 7 == 0
+                outputs.append(HostDeviceMem(host_mem, device_mem))
+                output_idx += 1
+        assert len(inputs) == 1
+        assert len(outputs) == 1
+        return inputs, outputs, bindings, stream
+
+    @staticmethod
+    def get_input_shape(engine):
+        """Get input shape of the TensorRT YOLO engine."""
+        binding = engine[0]
+        assert engine.binding_is_input(binding)
+        binding_dims = engine.get_binding_shape(binding)
+        if len(binding_dims) == 4:
+            return tuple(binding_dims[2:])
+        elif len(binding_dims) == 3:
+            return tuple(binding_dims[1:])
+        else:
+            raise ValueError('bad dims of binding %s: %s' % (binding, str(binding_dims)))
+
+
+    def do_inference_v2(self):
+        """do_inference_v2 (for TensorRT 7.0+)
+
+        This function is generalized for multiple inputs/outputs for full
+        dimension networks.
+        Inputs and outputs are expected to be 2 tuple of (host_mem, device_mem)
+        from allocate_buffers function.
+        """
+        # Transfer input data to the GPU.
+        [cuda.memcpy_htod_async(inp.device, inp.host, self.stream) for inp in self.inputs]
+        # Run inference.
+        self.context.execute_async_v2(bindings=self.bindings, stream_handle=self.stream.handle)
+        # Transfer predictions back from the GPU.
+        [cuda.memcpy_dtoh_async(out.host, out.device, self.stream) for out in self.outputs]
+        # Synchronize the stream
+        self.stream.synchronize()
+        # Return only the host outputs.
+        return [out.host for out in self.outputs]
+
+    @staticmethod
+    def _nms_boxes(detections, nms_threshold):
+        """Apply the Non-Maximum Suppression (NMS) algorithm on the bounding
+        boxes with their confidence scores and return an array with the
+        indexes of the bounding boxes we want to keep.
+
+        # Args
+            detections: Nx7 numpy arrays of
+                        [[x, y, w, h, box_confidence, class_id, class_prob],
+                        ......]
+        """
+        x_coord = detections[:, 0]
+        y_coord = detections[:, 1]
+        width = detections[:, 2]
+        height = detections[:, 3]
+        box_confidences = detections[:, 4]
+
+        areas = width * height
+        ordered = box_confidences.argsort()[::-1]
+
+        keep = list()
+        while ordered.size > 0:
+            # Index of the current element:
+            i = ordered[0]
+            keep.append(i)
+            xx1 = np.maximum(x_coord[i], x_coord[ordered[1:]])
+            yy1 = np.maximum(y_coord[i], y_coord[ordered[1:]])
+            xx2 = np.minimum(x_coord[i] + width[i], x_coord[ordered[1:]] + width[ordered[1:]])
+            yy2 = np.minimum(y_coord[i] + height[i], y_coord[ordered[1:]] + height[ordered[1:]])
+
+            width1 = np.maximum(0.0, xx2 - xx1)
+            height1 = np.maximum(0.0, yy2 - yy1)
+            intersection = width1 * height1
+            union = (areas[i] + areas[ordered[1:]] - intersection)
+            iou = intersection / union
+            indexes = np.where(iou <= nms_threshold)[0]
+            ordered = ordered[indexes + 1]
+
+        keep = np.array(keep)
+        return keep        
+
+    def _post_process(self, trt_outputs: List[np.ndarray],image):
+        """
+        Post process TRT output
+        
+        args:
+                trt_ouputs: a list of tensors where each tensor contans a
+                    multiple of 7 float32 numbers in the order of 
+                    [x, y, w, h, box_conf_score, class_id, class_prob]
+        return:
+                bbox: list of bbox coordinate in [x1,y1,x2,y2]
+                scores: list of bbox conf score
+                classes: list of class id
+        """
+        detections = []
+        for output in trt_outputs:
+            detection = output.reshape((-1,7))
+            detection = detection[detection[:,4] >= 0.1]
+            detections.append(detection)
+        detections = np.concatenate(detections,axis=0)
+
+        #NMS
+        nms_detections = np.zeros((0, 7), dtype=detections.dtype)
+        for class_id in set(detections[:, 5]):
+            idxs = np.where(detections[:, 5] == class_id)
+            cls_detections = detections[idxs]
+            keep = self._nms_boxes(cls_detections, 0.3)
+            nms_detections = np.concatenate(
+                [nms_detections, cls_detections[keep]], axis=0)
+
+        xx = nms_detections[:, 0].reshape(-1, 1)
+        yy = nms_detections[:, 1].reshape(-1, 1)
+        ww = nms_detections[:, 2].reshape(-1, 1)
+        hh = nms_detections[:, 3].reshape(-1, 1)
+        boxes = np.concatenate([xx, yy, xx+ww, yy+hh], axis=1)
+        scores = nms_detections[:, 4]
+        classes = nms_detections[:, 5]
+
+        # update the labels names of the object detected
+        # labels = np.asarray([self.class_labels[int(i)] for i in classes])
+
+        return boxes, classes, scores
+    
+    @staticmethod
+    def bbox_scaling(bboxes: List[list], scale_factor: float) -> List[list]:
+        """
+        To scale the width and height of bboxes from v4tiny
+        After the conversion of the model in .cfg and .weight file format, from
+        Alexey's Darknet repo, to tf model, bboxes are bigger.
+        So downscaling is required for a better fit
+        """
+        for idx, box in enumerate(bboxes):
+            x_1, y_1, x_2, y_2 = tuple(box)
+            center_x = (x_1 + x_2) / 2
+            center_y = (y_1 + y_2) / 2
+            scaled_x_1 = center_x - ((x_2 - x_1) / 2 * scale_factor)
+            scaled_x_2 = center_x + ((x_2 - x_1) / 2 * scale_factor)
+            scaled_y_1 = center_y - ((y_2 - y_1) / 2 * scale_factor)
+            scaled_y_2 = center_y + ((y_2 - y_1) / 2 * scale_factor)
+            bboxes[idx] = [scaled_x_1, scaled_y_1, scaled_x_2, scaled_y_2]
+
+        return bboxes
+
+    def predict(self, frame: np.array) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        
+        self.inputs, self.outputs, self.bindings, self.stream = \
+                self.allocate_buffers()
+
+        image_data  = cv2.resize(frame, (self.input_shape[1], self.input_shape[0]))
+        
+        image_data = cv2.cvtColor(image_data, cv2.COLOR_BGR2RGB)
+        image_data = image_data.transpose((2, 0, 1)).astype(np.float32)
+        image_data = image_data / 255.0
+    
+        self.inputs[0].host = np.ascontiguousarray(image_data)
+        if self.cuda_ctx:
+            self.cuda_ctx.push()
+        trt_outputs = self.do_inference_v2()
+        if self.cuda_ctx:
+            self.cuda_ctx.pop()
+
+        bboxes, labels, scores = self._post_process(trt_outputs,frame)
+
+
+        return bboxes, labels, scores
+
+
+

--- a/peekingduck/pipeline/nodes/model/yolo_TF_TRT.py
+++ b/peekingduck/pipeline/nodes/model/yolo_TF_TRT.py
@@ -1,0 +1,71 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Draw bounding boxes over detected object
+"""
+
+from typing import Any, Dict
+from peekingduck.pipeline.nodes.node import AbstractNode
+from peekingduck.pipeline.nodes.model.yolo_TF_TRTv1.detector import Detector
+
+
+class Node(AbstractNode):
+    """Draw bounding boxes on image.
+
+    The draw bbox node uses the bboxes and, optionally, the bbox labels from the model
+    predictions to draw the bbox predictions onto the image.
+    For better understanding of the usecase, refer to the
+    `object counting usecase <use_cases/object_counting.html>`_.
+
+    Inputs:
+
+        |img|
+
+        |bboxes|
+
+        |bbox_labels|
+
+    Outputs:
+        |none|
+
+    Configs:
+        show_labels (:obj:`bool`): **default = False**
+            Show class label, e.g. "person", above bounding box
+    """
+
+    def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
+        super().__init__(config, node_path=__name__, **kwargs)
+        self.model = Detector(self.config)
+
+
+    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Function that reads the image input and returns the bboxes
+        of the specified objects chosen to be detected
+
+        Args:
+            inputs (Dict): Dictionary of inputs with key "img"
+        Returns:
+            outputs (Dict): bbox output in dictionary format with keys
+            "bboxes", "bbox_labels" and "bbox_scores"
+        """
+
+        bboxes, labels, scores = self.model.predict(inputs["img"])
+        outputs = {
+            "bboxes": bboxes,
+            "bbox_labels": labels,
+            "bbox_scores": scores,
+        }
+
+        return outputs

--- a/peekingduck/pipeline/nodes/model/yolo_TF_TRTv1/__init__.py
+++ b/peekingduck/pipeline/nodes/model/yolo_TF_TRTv1/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Yolo-related files for TF_TRT yolo node
+"""

--- a/peekingduck/pipeline/nodes/model/yolo_TF_TRTv1/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolo_TF_TRTv1/detector.py
@@ -1,0 +1,156 @@
+"""yolo_with_plugins.py
+
+Implementation of TrtYOLO class with the yolo_layer plugins.
+"""
+
+
+from __future__ import print_function
+
+import ctypes
+
+import time
+
+import os
+import logging
+from typing import Dict, Any, List, Tuple
+import numpy as np
+import cv2
+import tensorflow as tf
+from tensorflow.python.compiler.tensorrt import trt_convert
+from tensorflow.python.saved_model import tag_constants
+
+
+class Detector:
+
+    def __init__(self, config: Dict[str, Any], cuda_ctx=None) -> None:
+        
+        self.config = config
+        self.root_dit = config["root"]
+        self.logger = logging.getLogger(__name__)
+        self.model_type = config["model_type"]
+
+        # TF-TRT
+        TRT_model_saved_dir = os.path.join(
+            self.config["root"], 
+            self.config["converted_model_path"][self.model_type])
+        if not os.path.isdir(TRT_model_saved_dir):
+            self.build_engine()
+
+        self.model = self._create_yolo_model()
+
+    def _create_yolo_model(self) -> Any:
+        """
+        Creates yolo model for license plate detection
+        """
+
+        # Load converted model and infer
+        converted_model_path = os.path.join(
+            self.config["root"], self.config["converted_model_path"][self.model_type]
+        )
+        model = tf.saved_model.load(converted_model_path, tags=[tag_constants.SERVING])
+
+        return model
+
+    def my_input_fn(self):
+        # input_fn: a generator function that yields input data as a list or tuple,
+        # which will be used to execute the converted signature to generate TensorRT
+        # engines.
+        input_shape = (1,self.config["size"],self.config["size"],3)
+        batched_input = np.zeros(input_shape, dtype=np.float32)
+        batched_input = tf.constant(batched_input)
+        yield (batched_input,)
+
+    def build_engine(self):
+
+        input_saved_model_dir = os.path.join(
+            self.config["root"], self.config["model_weights_dir"][self.model_type]
+        )
+
+        # Conversion Parameters 
+        conversion_params = trt_convert.TrtConversionParams(
+            precision_mode=trt_convert.TrtPrecisionMode.FP16,
+            max_workspace_size_bytes=4000000000,
+            max_batch_size=1)
+        
+        converter = trt_convert.TrtGraphConverterV2(
+            input_saved_model_dir=input_saved_model_dir,
+            conversion_params=conversion_params)
+
+        print('Building the TensorRT engine.  This would take a while...')
+        t = time.process_time()
+        # Converter method used to partition and optimize TensorRT compatible segments
+        converter.convert()
+
+        # Optionally, build TensorRT engines before deployment to save time at runtime
+        # Note that this is GPU specific, and as a rule of thumb, we recommend building at runtime
+        converter.build(input_fn=self.my_input_fn)
+
+        # Save the converted model
+        converted_model_path = os.path.join(
+            self.config["root"], self.config["converted_model_path"][self.model_type]
+        )
+        converter.save(converted_model_path)
+
+        elapsed_time = time.process_time() - t
+        print(f"TensorRT engine built in {elapsed_time} secs")
+    
+    @staticmethod
+    def bbox_scaling(bboxes: List[list], scale_factor: float) -> List[list]:
+        """
+        To scale the width and height of bboxes from v4tiny
+        After the conversion of the model in .cfg and .weight file format, from
+        Alexey's Darknet repo, to tf model, bboxes are bigger.
+        So downscaling is required for a better fit
+        """
+        for idx, box in enumerate(bboxes):
+            x_1, y_1, x_2, y_2 = tuple(box)
+            center_x = (x_1 + x_2) / 2
+            center_y = (y_1 + y_2) / 2
+            scaled_x_1 = center_x - ((x_2 - x_1) / 2 * scale_factor)
+            scaled_x_2 = center_x + ((x_2 - x_1) / 2 * scale_factor)
+            scaled_y_1 = center_y - ((y_2 - y_1) / 2 * scale_factor)
+            scaled_y_2 = center_y + ((y_2 - y_1) / 2 * scale_factor)
+            bboxes[idx] = [scaled_x_1, scaled_y_1, scaled_x_2, scaled_y_2]
+
+        return bboxes
+
+    def predict(self, frame: np.array) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+
+        #TF-TRT
+        image_data  = cv2.resize(frame, (self.config["size"], self.config["size"]))
+        image_data = image_data / 255.0
+        image_data = np.asarray([image_data]).astype(np.float32)
+        batch_data = tf.constant(image_data)
+        func = self.model.signatures['serving_default']
+        output = func(batch_data)
+        for _, value in output.items():
+            pred_conf = value[:, :, 4:]
+            boxes = value[:, :, 0:4]
+
+        # performs nms using model's predictions
+        bboxes, scores, classes, nums = tf.image.combined_non_max_suppression(
+            tf.reshape(boxes, (tf.shape(boxes)[0], -1, 1, 4)),
+            tf.reshape(
+                pred_conf, (tf.shape(pred_conf)[0], -1, tf.shape(pred_conf)[-1])),
+            self.config['max_output_size_per_class'],
+            self.config['max_total_size'],
+            self.config['yolo_iou_threshold'],
+            self.config['yolo_score_threshold']
+        )
+        classes = classes.numpy()[0]
+        classes = classes[: nums[0]]
+        bboxes = bboxes.numpy()[0]
+        bboxes = bboxes[: nums[0]]
+        scores = scores.numpy()[0]
+        scores = scores[: nums[0]]
+
+        bboxes[:, [0, 1]] = bboxes[:, [1, 0]]  # swapping x and y axes
+        bboxes[:, [2, 3]] = bboxes[:, [3, 2]]
+
+        # scaling of bboxes if v4tiny model is used
+        if self.config["model_type"] == "v4tiny":
+            bboxes = self.bbox_scaling(bboxes, 0.75)
+
+        return bboxes, classes, scores
+
+


### PR DESCRIPTION
Created two nodes for tensorRT inference. Requires TensorRT, protobuf=3.8.0 and pycuda installed
Refer to the notion page for more details: https://www.notion.so/TensorRT-d63035adb45c43e180a2517c9fce474d

yolo_TF_TRT:
-Builds a tensortRT optimized saved_model format using the TF TensorRT API
-Requires the saved model directory of yolov4 and yolov4tiny
-File path of the newly built tensorRT saved_model can be editied in the config file

tensorRT:
-use a  preconverted .trt yolov4 and yolov4tiny model for inference
-Following the notion page, yolov4/v4tiny models converted from darknet weigjts > onnx > .trt
-requires precompiling of C++ plugin, currently the plugin is referenced from another repo found in the notion page. If this specific method is adopted, the plugin folder has to be replicated from the other repo.
-The plugin path then has to be updated in the config file

