### PR TITLE
Fix package data

### DIFF
--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -78,7 +78,7 @@ class Runner:
                 self.logger.error(str(error))
                 sys.exit(1)
         if RequirementChecker.n_update > 0:
-            sys.exit(1)
+            sys.exit(3)
 
     def run(self) -> None:
         """execute single or continuous inference"""

--- a/scripts/usecase_tests.sh
+++ b/scripts/usecase_tests.sh
@@ -10,10 +10,11 @@ do
     eval $command
     ret_code=$?
 
-    if [ $ret_code -eq 3 ] && ! (eval $command); then
-        echo "USECASE TESTING $use_case FAILED."
-        exit 123
-    elif [ $ret_code -ne 0 ]; then
+    if [ $ret_code -eq 3 ]; then
+        eval $command
+        ret_code=$?
+    fi
+    if [ $ret_code -ne 0 ]; then
         echo "USECASE TESTING $use_case FAILED."
         exit 123
     fi

--- a/scripts/usecase_tests.sh
+++ b/scripts/usecase_tests.sh
@@ -2,10 +2,18 @@
 # author: jin jun
 # date  : 31/05/2021
 # this script runs all usecases and throws an error if there are crashes
+# Attempts a re-run with exit code 3 (optional package installed)
 
 for use_case in "tests/use_cases"/*
 do
-    if ! (peekingduck run --config_path="$use_case"); then
+    command="peekingduck run --config_path='$use_case'"
+    eval $command
+    ret_code=$?
+
+    if [ $ret_code -eq 3 ] && ! (eval $command); then
+        echo "USECASE TESTING $use_case FAILED."
+        exit 123
+    elif [ $ret_code -ne 0 ]; then
         echo "USECASE TESTING $use_case FAILED."
         exit 123
     fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,9 @@ include_package_data = True
 # TBD: Different extras for `full` and `edge`
 # [options.extras_require]
 
+[options.package_data]
+* = configs/*/*.yml, optional_requirements.txt
+
 [options.packages.find]
 include = peekingduck, peekingduck.*
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -180,8 +180,10 @@ class TestRunner:
         with mock.patch.object(RequirementChecker, "n_update", 1), mock.patch(
             "peekingduck.declarative_loader.DeclarativeLoader.get_pipeline",
             wraps=get_pipeline_with_default_node_names,
-        ), pytest.raises(SystemExit):
+        ), pytest.raises(SystemExit) as exec_info:
             Runner(RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, CUSTOM_DIR)
+        # Ensure we are throwing the correct exit code
+        assert exec_info.value.code == 3
 
     def test_run(self, runner_with_nodes):
         with mock.patch(


### PR DESCRIPTION
Fixes failing Daily Drift Checks.

**Issue description**:
Daily Drift Checks are failing with `FileNotFoundError: [Errno 2] No such file or directory: '/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/peekingduck/optional_requirements.txt'`

**Investigation**:
`setup-python@v2` sets up `setuptools==40.6.2` by default while latest version at time of PR is `>=58.5.3`. Between these version, a [fix](https://setuptools.pypa.io/en/latest/history.html#v58-5-0) for inconsistency with `include_package_data` and `package_data` was made. [Details](https://github.com/pypa/setuptools/issues/1461).

Daily Drift Checks attempts to install `peekingduck` when `setuptools` is at the old version, this caused `optional_requirements.txt` to get omitted.

**Fix**:
The `[options.package_data]` has to be included until `setup-python@v2` sets up `setuptools>=58.5.3` by default.

Additional fix to `actions/system-test` is required since the `zone_count` will exit early due to package update. [`runner.py`](https://github.com/liyier90/PeekingDuck/blob/baa5ac963d46d03d9eb2b911ccf9a25121bd4881/peekingduck/runner.py#L80) has been changed to give `exit code=3` when there is package updates and [`scripts/usecase_tests.sh`](https://github.com/liyier90/PeekingDuck/blob/baa5ac963d46d03d9eb2b911ccf9a25121bd4881/scripts/usecase_tests.sh) has been changed to attempt a re-run when there is `exit code=3`.

**Note**: Previous Daily Drift Checks failure were caused by a missing upper bound for certain packages ([details](https://github.com/tensorflow/tensorflow/releases/tag/v2.6.2)) and is unrelated to PeekingDuck code.