### PR TITLE
Feat fast mosaic

### DIFF
--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -66,10 +66,10 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             bboxes (List[np.ndarray]): numpy array of detected bboxes
 
         Returns:
-            (np.ndarray): Image with mosaiced bounding box regions.
+            (np.ndarray): Image with mosaicked bounding box regions.
         """
         height, width = image.shape[:2]
-        # Prevent calculating mosaic on a mosaiced area
+        # Prevent calculating mosaic on a mosaicked area
         original_image = image.copy()
 
         for bbox in bboxes:
@@ -89,7 +89,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             image (np.ndarray): Image in numpy array.
 
         Returns:
-            (np.ndarray): Mosaic-ed image in numpy array.
+            (np.ndarray): Mosaicked image in numpy array.
         """
         height, width = image.shape[:2]
         image = cv2.resize(

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -17,6 +17,7 @@ Mosaics area bounded by bounding boxes over detected object
 """
 
 from typing import Any, Dict, List
+
 import cv2
 import numpy as np
 
@@ -53,62 +54,49 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         self.mosaic_level = self.config["mosaic_level"]
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        mosaic_img = self.mosaic_bbox(inputs["img"], inputs["bboxes"])
+        mosaic_img = self._mosaic_bbox(inputs["img"], inputs["bboxes"])
         outputs = {"img": mosaic_img}
         return outputs
 
-    def mosaic_bbox(self, image: np.ndarray, bboxes: List[np.ndarray]) -> np.ndarray:
-        """Mosaics areas bounded by bounding boxes on image
+    def _mosaic_bbox(self, image: np.ndarray, bboxes: List[np.ndarray]) -> np.ndarray:
+        """Mosaics areas bounded by bounding boxes on ``image``.
 
         Args:
-            image (np.ndarray): image in numpy array
-            bboxes (np.ndarray): numpy array of detected bboxes
+            image (np.ndarray): Image in numpy array.
+            bboxes (List[np.ndarray]): numpy array of detected bboxes
 
         Returns:
-            image (np.ndarray): image in numpy array
+            (np.ndarray): Image with mosaiced bounding box regions.
         """
-        height = image.shape[0]
-        width = image.shape[1]
+        height, width = image.shape[:2]
+        # Prevent calculating mosaic on a mosaiced area
+        original_image = image.copy()
 
         for bbox in bboxes:
-            x_1, y_1, x_2, y_2 = bbox
-            x_1, x_2 = int(x_1 * width), int(x_2 * width)
-            y_1, y_2 = int(y_1 * height), int(y_2 * height)
+            # bbox can contain negative values sometimes, ensures the ROI
+            # selection is within bounds and without wrapping
+            rows = slice(int(max(0, bbox[1]) * height), int(min(1, bbox[3]) * height))
+            cols = slice(int(max(0, bbox[0]) * width), int(min(1, bbox[2]) * width))
 
-            # slice the image to get the area bounded by bbox
-            bbox_image = image[y_1:y_2, x_1:x_2, :].copy()
-            mosaic_bbox_image = self.mosaic(bbox_image, self.mosaic_level)
-            image[y_1:y_2, x_1:x_2, :] = mosaic_bbox_image
+            image[rows, cols] = self._mosaic(original_image[rows, cols])
 
         return image
 
-    @staticmethod
-    def mosaic(  # pylint: disable-msg=too-many-locals
-        image: np.ndarray, mosaic_level: int
-    ) -> np.ndarray:
-        """Mosaics a given input image
+    def _mosaic(self, image: np.ndarray) -> np.ndarray:
+        """Mosaics a given input image.
 
         Args:
-            image (np.ndarray): image in numpy array
+            image (np.ndarray): Image in numpy array.
 
         Returns:
-            image (np.ndarray): image in numpy array
+            (np.ndarray): Mosaic-ed image in numpy array.
         """
-        (height, width) = image.shape[:2]
-        x_steps = np.linspace(0, width, mosaic_level + 1, dtype="int")
-        y_steps = np.linspace(0, height, mosaic_level + 1, dtype="int")
-
-        for i in range(1, len(y_steps)):
-            for j in range(1, len(x_steps)):
-                start_x = x_steps[j - 1]
-                start_y = y_steps[i - 1]
-                end_x = x_steps[j]
-                end_y = y_steps[i]
-
-                roi = image[start_y:end_y, start_x:end_x]
-                (blue, green, red) = [int(x) for x in cv2.mean(roi)[:3]]
-                cv2.rectangle(
-                    image, (start_x, start_y), (end_x, end_y), (blue, green, red), -1
-                )
+        height, width = image.shape[:2]
+        image = cv2.resize(
+            image,
+            (self.mosaic_level, self.mosaic_level),
+            interpolation=cv2.INTER_LANCZOS4,
+        )
+        image = cv2.resize(image, (width, height), interpolation=cv2.INTER_NEAREST)
 
         return image


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck/issues/519

Changes include:
- Change underlying mosaic algorithm to use 2x `cv2.resize()`
  - A downsize to (`mosaic_level`, `mosaic_level`) followed by an upsize to the original size
- Change both `mosaic_bbox` and `mosaic` to private
- Convert `mosaic` to an instance method so it can access `self.mosaic_level` directly without have to be passed in as an argument
- Check that `bbox` coordinates are within bounds

There are some differences in the mosaiced output between the current implementation and PR implementation:
| Current | PR | Remarks |
|---------|----|---------|
| ![jim_curr](https://user-images.githubusercontent.com/56420072/142155866-1debe75e-df12-4998-8deb-f3b02e490770.gif) | ![jim_fast](https://user-images.githubusercontent.com/56420072/142155879-03f7a67a-5798-49ed-98cc-1ee4e388cc91.gif) | 1280 x 720 video with `mosaic_level=7`<br> Output may appear jittery as it is more sensitive to source pixel color |
| ![michael_curr](https://user-images.githubusercontent.com/56420072/142155580-88647248-cac7-45d0-b480-063d23c14a17.gif) | ![michae_fast](https://user-images.githubusercontent.com/56420072/142155589-b63b6346-bf2b-4961-8cad-9991debc53e6.gif) | 1280 x 720 video with `mosaic_level=17`<br> Jitteriness is less noticeable with higher `mosaic_level` |
| ![multiple_curr](https://user-images.githubusercontent.com/56420072/142156028-0ea37e7b-fe77-452a-80fe-77e14b9853c6.gif) | ![multiple_fast](https://user-images.githubusercontent.com/56420072/142156078-3390e89c-5856-4011-b19a-5bd5f5a9fdd5.gif) | 1280 x 720 video with `mosaic_level=7`<br> Less noticeable with smaller bounding boxes too |

While a robust comparison was not performed, the PR implementation provides an improvement in FPS performance for rows 2 and 3 in the above table:
- 23.94 vs 25.26 FPS
- 19.99 vs 21.49 FPS

**NOTE**: Similar to the current implementation, the PR implementation does not check that an appropriate `mosaic_level` is used. When `mosaic_level` is large or approximately same as bbox size, the output is not "properly" mosaiced, i.e., the person's privacy is not actually protected.
