### PR TITLE
Fix post merge test failures

### DIFF
--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -68,9 +68,10 @@ class VideoThread:
         self.is_thread_start.wait()
 
     def __del__(self) -> None:
-        # dotw: self.logger.debug below crashes on Nvidia Jetson Xavier Ubuntu 18.04 python 3.6
-        #       but does not crash on Intel MacBook Pro Ubuntu 20.04 python 3.7
-        # self.logger.debug("VideoThread.__del__")
+        """
+        Release acquired resources here.
+        """
+        self.logger.debug("VideoThread.__del__")
         self.stream.release()
 
     def shutdown(self) -> None:

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -32,7 +32,7 @@ def get_fps_number(avg_fps_msg: str) -> float:
 
 
 @contextmanager
-def config_yml():
+def run_config_yml():
     """Save and restore current run_config.yml"""
     try:
         config_saved = False
@@ -113,18 +113,17 @@ def test_input_threading():
             if dur > num_sec:
                 break
         proc.kill()
+        os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
 
         return avg_fps
 
     res = False
-    with config_yml():
+    with run_config_yml():
         print("Run test without threading")
         avg_fps_1 = run_rtsp_test(url=RTSP_URL, threading=False)
-        os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
 
         print("Run test with threading")
         avg_fps_2 = run_rtsp_test(url=RTSP_URL, threading=True)
-        os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
 
         res = avg_fps_2 > avg_fps_1
         print(f"avg_fps_1={avg_fps_1}, avg_fps_2={avg_fps_2}, res={res}")

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 import subprocess
 from time import perf_counter
 from pathlib import Path
@@ -30,19 +31,34 @@ def get_fps_number(avg_fps_msg: str) -> float:
     return avg_fps
 
 
+@contextmanager
+def config_yml():
+    """Save and restore current run_config.yml"""
+    try:
+        config_saved = False
+        if os.path.isfile(PKD_CONFIG_ORIG_PATH):
+            print("Backup existing run_config.yml")
+            os.rename(src=PKD_CONFIG_ORIG_PATH, dst=PKD_CONFIG_BAK_PATH)
+            config_saved = True
+        yield
+    finally:
+        if config_saved:
+            print("Restore backed up run_config.yml")
+            os.rename(src=PKD_CONFIG_BAK_PATH, dst=PKD_CONFIG_ORIG_PATH)
+
+
 # Unit Tests
 def test_input_threading():
     """Run input threading unit test.
 
     This test will do the following:
-    1. Prepare unit test environment
-    2. Backup original run_config.yml in Peeking Duck directory
-    3. Run input live test 1 without threading with custom run_config.yml file
+    1. Backup original run_config.yml in Peeking Duck directory
+    2. Run input live test 1 without threading with custom run_config.yml file
        The test comprises input.live, model.yolo and dabble.fps
-    4. Run input live test 2 with threading with custom run_config.yml file
+    3. Run input live test 2 with threading with custom run_config.yml file
        The test comprises input.live, model.yolo and dabble.fps
-    5. Restore original run_config.yml
-    6. Check average FPS from 2 is higher than 1
+    4. Restore original run_config.yml
+    5. Check average FPS from 2 is higher than 1
     """
 
     def run_rtsp_test(url: str, threading: bool) -> float:
@@ -79,7 +95,11 @@ def test_input_threading():
         avg_fps = 0
         cmd = ["python", "PeekingDuck"]
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1
+            cmd,
+            cwd=PKD_RUN_DIR,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
         )
         st = perf_counter()
         while True:
@@ -96,24 +116,16 @@ def test_input_threading():
 
         return avg_fps
 
-    # 1. Setup unit test environment
-    os.chdir(PKD_RUN_DIR)
+    res = False
+    with config_yml():
+        print("Run test without threading")
+        avg_fps_1 = run_rtsp_test(url=RTSP_URL, threading=False)
+        os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
 
-    # 2. Backup original run_config.yml
-    os.rename(src=PKD_CONFIG_ORIG_PATH, dst=PKD_CONFIG_BAK_PATH)
+        print("Run test with threading")
+        avg_fps_2 = run_rtsp_test(url=RTSP_URL, threading=True)
+        os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
 
-    # 3. Run input live test without threading
-    avg_fps_1 = run_rtsp_test(url=RTSP_URL, threading=False)
-    os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
-
-    # 4. Run input live test with threading
-    avg_fps_2 = run_rtsp_test(url=RTSP_URL, threading=True)
-    os.remove(PKD_CONFIG_ORIG_PATH)  # delete unit test yml
-
-    # 5. Restore original config
-    os.rename(src=PKD_CONFIG_BAK_PATH, dst=PKD_CONFIG_ORIG_PATH)
-
-    # 6. Check we get higher FPS for 2 than 1
-    res = avg_fps_2 > avg_fps_1
-    print(f"avg_fps_1={avg_fps_1}, avg_fps_2={avg_fps_2}, res={res}")
+        res = avg_fps_2 > avg_fps_1
+        print(f"avg_fps_1={avg_fps_1}, avg_fps_2={avg_fps_2}, res={res}")
     assert res


### PR DESCRIPTION
Fixes #531 with the following upgrades:

Improved threading unit test code to make it more robust:
1. Delete the destructive `os.chdir()` call.
2. Pass the working directory to `subprocess.Popen()` call instead.
3. Shifted the backup and restore of existing `run_config.yml` into a context manager to ensure resources are properly restored in the event of an exception or crash.
(tested by CTRL-C breaking the threading unit test)

Also took the chance to enable debug output in `input/utils/read.py` `VideoThread.__del__` as the `subprocess.Popen()` no longer crashes upon exit on Nvidia Jetson Xavier Ubuntu 18.04 (tested).
