### PR TITLE
Fixed sphinx error on Windows when building html

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=build
+set READTHEDOCS=1
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
Closes #533 

Changes:

* Added `set READTHEDOCS=1` in make.bat, solves the `Extension Error` when building the sphinx html docs on Windows



