### PR TITLE
Feat: Run custom project/nodes in dev mode

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -47,7 +47,7 @@ def main(context: click.Context, config_path: str, log_level: str) -> None:
     if config_path is None:
         pkd_dir = Path(__file__).resolve().parent
         config_path = str(pkd_dir / "run_config.yml")
-        nodes_parent_dir = "PeekingDuck"
+        nodes_parent_dir = pkd_dir.name
     else:
         nodes_parent_dir = "src"
 

--- a/__main__.py
+++ b/__main__.py
@@ -17,11 +17,11 @@ Workaround for running Peekingduck from project directory
 """
 
 import logging
-import click
 from pathlib import Path
-from peekingduck.cli import cli
-from peekingduck.utils.logger import LoggerSetup
-import peekingduck.runner as pkd
+
+import click
+
+from peekingduck.cli import cli, run
 
 
 @cli.command()
@@ -30,7 +30,8 @@ import peekingduck.runner as pkd
     default=None,
     type=click.Path(),
     help=(
-        "List of nodes to run. None assumes run_config.yml at current working directory"
+        "List of nodes to run. None assumes run_config.yml is in the same "
+        "directory as __main__.py"
     ),
 )
 @click.option(
@@ -38,18 +39,29 @@ import peekingduck.runner as pkd
     default="info",
     help="""Modify log level {"critical", "error", "warning", "info", "debug"}""",
 )
-def run(config_path: str, log_level: str) -> None:
-    if not config_path:
-        pkd_dir = Path(__file__).parent
-        config_path = pkd_dir / "run_config.yml"
+@click.pass_context
+def main(context: click.Context, config_path: str, log_level: str) -> None:
+    """Invokes the run() CLI command with some different defaults for
+    ``node_config`` and ``nodes_parent_dir``.
+    """
+    if config_path is None:
+        pkd_dir = Path(__file__).resolve().parent
+        config_path = str(pkd_dir / "run_config.yml")
+        nodes_parent_dir = "PeekingDuck"
+    else:
+        nodes_parent_dir = "src"
 
-    LoggerSetup(log_level=log_level)
     logger = logging.getLogger(__name__)
     logger.info(f"Run path: {config_path}")
 
-    runner = pkd.Runner(config_path, "None", "PeekingDuck")
-    runner.run()
+    context.invoke(
+        run,
+        config_path=config_path,
+        node_config="None",
+        log_level=log_level,
+        nodes_parent_dir=nodes_parent_dir,
+    )
 
 
 if __name__ == "__main__":
-    run()
+    main()  # pylint: disable=no-value-for-parameter

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -97,7 +97,9 @@ def init(custom_folder_name: str) -> None:
     default="info",
     help="""Modify log level {"critical", "error", "warning", "info", "debug"}""",
 )
-def run(config_path: str, node_config: str, log_level: str) -> None:
+def run(
+    config_path: str, node_config: str, log_level: str, nodes_parent_dir: str = "src"
+) -> None:
     """Runs PeekingDuck"""
     LoggerSetup.set_log_level(log_level)
 
@@ -107,7 +109,7 @@ def run(config_path: str, node_config: str, log_level: str) -> None:
     else:
         run_config_path = Path(config_path)
 
-    runner = Runner(run_config_path, node_config, "src")
+    runner = Runner(run_config_path, node_config, nodes_parent_dir)
     runner.run()
 
 


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/13

A detailed description of the issue faced and various use cases enabled by this PR can be found in the comments thread of the origin issue.

**Changes**:
- Change dev mode to invoke CLI `run()` command from `cli.py` with `click.pass_context`
  - Make the call to `Runner.run()` more consistent, can avoid duplicating some of the pre-run setups.
- Set `custom_nodes_parent_subdir="src"` when running in dev mode with `config_path` option
  - So that PKD will have access to `custom_nodes` in custom projects
  - This will break workflows that keeps `custom_nodes` in the `PeekingDuck` directory **and** is calling with the `config_path` CLI option
    - Simply calling `python PeekingDuck` will still work
    - As a bonus, this PR also enables calling `python PeekingDuck-<altname>` with custom nodes in the `PeekingDuck-<altname>` directory.
- Added `.resolve()` to `pkd_dir` so the logged path looks nicer.

