### PR TITLE
cicd: pin pypi-publish version to v1.4.2

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install build --user
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
@@ -59,7 +59,7 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         # only pushes to actual PyPI if its a tag (i.e. on release: published)
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/publish_skip_testpypi.yml
+++ b/.github/workflows/publish_skip_testpypi.yml
@@ -1,8 +1,7 @@
 name: Skip Test Pypi and Publish to Pypi
 env:
   VERSION: v1.0.3
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   local-install-test:
@@ -44,7 +43,7 @@ jobs:
           python -m pip install build --user
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 


### PR DESCRIPTION
**Issue**:
The publish workflow is currently using `pypa/gh-action-pypi-publish@master` which uses the `master` branch pointer instead of being pinned to a specific tagged version.

The [recommendation](https://github.com/pypa/gh-action-pypi-publish#usage) from the PyPI publish repo is to pin to a tagged version for more reproducible/secure builds. *Note: the example given in the repo at the time of this PR is still using a branch pointer `version/v1` instead of a tagged version.*

**Changes:**
For reference, the [publish workflow](https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/publish_pypi.yml#L38) for scikit-learn pins to `v1.4.1`.

Based on the latest logs from PeekingDuck's publish workflow: 
```
 Download action repository 'pypa/gh-action-pypi-publish@master' (SHA:bea5cda687c2b79989126d589ef4411bedce0195)
```
we have successfully built and published using commit [bea5cda](https://github.com/pypa/gh-action-pypi-publish/commit/54b39fb9371c0b3a6f9f14bb8a67394defc7a806) from the `master` branch. And since [between `v1.4.2` and `master`](https://github.com/pypa/gh-action-pypi-publish/compare/v1.4.2...master) (at the time of this PR), there are only commits to the `README.md`, we can safely pin to `v1.4.2` instead.