### PR TITLE
Add configurable options to improve `output.screen` node

### DIFF
--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -1,2 +1,8 @@
 input: ["img"]
 output: ["pipeline_end"]
+
+window_name: PeekingDuck
+window_width: 1280
+window_height: 720
+window_x_coord: 0
+window_y_coord: 0

--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -3,6 +3,7 @@ output: ["pipeline_end"]
 
 window_name: "PeekingDuck"
 window_size: {
+    do_resizing: False,
     width: 1280,
     height: 720 
 }

--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -1,8 +1,12 @@
 input: ["img"]
 output: ["pipeline_end"]
 
-window_name: PeekingDuck
-window_width: 1280
-window_height: 720
-window_x_coord: 0
-window_y_coord: 0
+window_name: "PeekingDuck"
+window_size: {
+    width: 1280,
+    height: 720 
+}
+window_loc: {
+    x: 0,
+    y: 0
+}

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -38,7 +38,8 @@ class Node(AbstractNode):
         window_size (:obj:`Dict`):
             **default = { do_resizing: False, width: 1280, height: 720 }** |br|
             Resizes the displayed window to the chosen width and weight, if ``do_resizing``
-            is set to ``true``.
+            is set to ``true``. The size of the displayed window can also be adjusted by
+            clicking and dragging.
         window_loc (:obj:`Dict`): **default = { x: 0, y: 0 }** |br|
             X and Y coordinates of the top left corner of the displayed window, with
             reference from the top left corner of the screen, in pixels.

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -35,8 +35,10 @@ class Node(AbstractNode):
     Configs:
         window_name (:obj:`str`): **default = "PeekingDuck"** |br|
             Name of the displayed window.
-        window_size (:obj:`Dict`): **default = { width: 1280, height: 720 }** |br|
-            Width and height of the displayed window, in pixels.
+        window_size (:obj:`Dict`):
+            **default = { do_resizing: False, width: 1280, height: 720 }** |br|
+            Resizes the displayed window to the chosen width and weight, if ``do_resizing``
+            is set to ``true``.
         window_loc (:obj:`Dict`): **default = { x: 0, y: 0 }** |br|
             X and Y coordinates of the top left corner of the displayed window, with
             reference from the top left corner of the screen, in pixels.
@@ -46,14 +48,17 @@ class Node(AbstractNode):
         super().__init__(config, node_path=__name__, **kwargs)
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
-        cv2.resizeWindow(
-            self.window_name, self.window_size["width"], self.window_size["height"]
-        )
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
 
-        cv2.imshow(self.window_name, inputs["img"])
+        if not self.window_size["do_resizing"]:
+            cv2.imshow(self.window_name, inputs["img"])
+        else:
+            resized_img = cv2.resize(
+                inputs["img"], (self.window_size["width"], self.window_size["height"])
+            )
+            cv2.imshow(self.window_name, resized_img)
 
         if cv2.waitKey(1) & 0xFF == ord("q"):
             cv2.destroyWindow(self.window_name)

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -35,23 +35,20 @@ class Node(AbstractNode):
     Configs:
         window_name (:obj:`str`): **default = "PeekingDuck"** |br|
             Name of the displayed window.
-        window_width (:obj:`int`): **default = 1280** |br|
-            Width of the displayed window, in pixels.
-        window_height (:obj:`int`): **default = 720** |br|
-            Height of the displayed window, in pixels.
-        window_x_coord (:obj:`int`): **default = 0** |br|
-            X-coordinate of the top left corner of the displayed window, with reference
-            from the top left corner of the screen, in pixels.
-        window_y_coord (:obj:`int`): **default = 0** |br|
-            Y-coordinate of the top left corner of the displayed window, with reference
-            from the top left corner of the screen, in pixels.
+        window_size (:obj:`Dict`): **default = { width: 1280, height: 720 }** |br|
+            Width and height of the displayed window, in pixels.
+        window_loc (:obj:`Dict`): **default = { x: 0, y: 0 }** |br|
+            X and Y coordinates of the top left corner of the displayed window, with
+            reference from the top left corner of the screen, in pixels.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
-        cv2.moveWindow(self.window_name, self.window_x_coord, self.window_y_coord)
-        cv2.resizeWindow(self.window_name, self.window_width, self.window_height)
+        cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
+        cv2.resizeWindow(
+            self.window_name, self.window_size["width"], self.window_size["height"]
+        )
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -33,17 +33,33 @@ class Node(AbstractNode):
         |pipeline_end|
 
     Configs:
-        None.
+        window_name (:obj:`str`): **default = "PeekingDuck"** |br|
+            Name of the displayed window.
+        window_width (:obj:`int`): **default = 1280** |br|
+            Width of the displayed window, in pixels.
+        window_height (:obj:`int`): **default = 720** |br|
+            Height of the displayed window, in pixels.
+        window_x_coord (:obj:`int`): **default = 0** |br|
+            X-coordinate of the top left corner of the displayed window, with reference
+            from the top left corner of the screen, in pixels.
+        window_y_coord (:obj:`int`): **default = 0** |br|
+            Y-coordinate of the top left corner of the displayed window, with reference
+            from the top left corner of the screen, in pixels.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
+        cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
+        cv2.moveWindow(self.window_name, self.window_x_coord, self.window_y_coord)
+        cv2.resizeWindow(self.window_name, self.window_width, self.window_height)
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
-        cv2.imshow("PeekingDuck", inputs["img"])
+
+        cv2.imshow(self.window_name, inputs["img"])
 
         if cv2.waitKey(1) & 0xFF == ord("q"):
+            cv2.destroyWindow(self.window_name)
             return {"pipeline_end": True}
 
         return {"pipeline_end": False}

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -52,13 +52,12 @@ class Node(AbstractNode):
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
 
-        if not self.window_size["do_resizing"]:
-            cv2.imshow(self.window_name, inputs["img"])
-        else:
-            resized_img = cv2.resize(
-                inputs["img"], (self.window_size["width"], self.window_size["height"])
+        img = inputs["img"]
+        if self.window_size["do_resizing"]:
+            img = cv2.resize(
+                img, (self.window_size["width"], self.window_size["height"])
             )
-            cv2.imshow(self.window_name, resized_img)
+        cv2.imshow(self.window_name, img)
 
         if cv2.waitKey(1) & 0xFF == ord("q"):
             cv2.destroyWindow(self.window_name)


### PR DESCRIPTION
closes #543 

Summary of improvements:
1. Gives users the option to resize the output window via configs, for situations such as high-res videos on a small laptop screen, where not the entire output window can be seen
2. The window size can now also be adjusted by clicking and dragging the output window
3. The top left corner of the output window will now be at the top left corner of the screen by default. It can also be changed in the configs. Previously, the top left corner of the output window would be around the middle of my screen, and I always had to drag the output window up to see the whole thing.
4. Gives users the option to change the name of the output window, when previously it was fixed as "PeekingDuck"