### PR TITLE
Feat: create node parse config

### DIFF
--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -61,87 +61,17 @@ As PeekingDuck runs the pipeline sequentially, it is important to check if the n
 
 ## Step 3: Generate Template Node Config and Script
 
-We recommend using the `peekingduck create-node` command to generate the template config and script files for your custom node through an interactive process as demonstrated below.
+We recommend using the `peekingduck create-node` command with the `--config_path` flag to generate
+the template config and script files for the custom nodes defined in your `run_config.yml` as
+demonstrated below.
 ```
-> peekingduck create-node
-Creating new custom node...
-Enter node directory relative to /path/to/<project_name> [src/custom_nodes]:
-Select node type (input, model, draw, dabble, output): output
-Enter node name [my_custom_node]: csv_writer
-
-Node directory:	/path/to/<project_name>/src/custom_nodes
-Node type:	output
-Node name:	csv_writer
-
-Creating the following files:
-	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
-	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
-Proceed? [Y/n]: 
-Created node!
+> peekingduck create-node --config_path run_config.yml
 ```
-
-### Step 3a: Enter Your Custom Node Parent Directory
-
-```
-Enter node directory relative to /path/to/<project_name> [src/custom_nodes]:
-```
-Enter the path of your custom node directory, ensure the path is relative to `<project_name>`, e.g.
-`src/<custom_folder_name>`. The default value `src/custom_nodes` is used in this guide.
-
-### Step 3b: Select a Node Type for Your Custom Node
-
-```text
-Select node type (input, model, draw, dabble, output): output
-```
-Select a node type from one of the five node types in PeekingDuck `(input, model, draw, dabble, output)`.
-`output` type is selected in this guide.
-
-### Step 3c: Enter Your Custom Node Name
-
-```
-Enter node name [my_custom_node]: csv_writer
-```
-Enter a name for your custom node. Some checks are performed in the background to ensure that the
-node name is valid and does not already exist (to prevent existing files from being overwritten).
-The default value is `my_custom_node` but `csv_writer` is used in this guide.
-
-### Step 3d: Confirm Node Creation
-
-```
-Node directory:	/path/to/<project_name>/src/custom_nodes
-Node type:	output
-Node name:	csv_writer
-
-Creating the following files:
-	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
-	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
-Proceed? [Y/n]: 
-```
-The full paths of the config and script files to be created will be shown for verification. You can
-abort the process by entering `n`. The default value of `y` is selected in this guide.
-
-### Alternative: Use `peekingduck create-node` with Command-line Options
-
-If you would like to speed things up a little and skip the interactive process, the command-line
-options `--node_subdir`, `--node_type`, `--node_name` can be used with `peekingduck create-node`.
-Step 3a-c from above can be replicated with command-line options as demonstrated below.
-```
-> peekingduck create-node --node_subdir src/custom_nodes --node_type output --node_name csv_writer
-Creating new custom node...
-
-Node directory:	/path/to/<project_name>/src/custom_nodes
-Node type:	output
-Node name:	csv_writer
-
-Creating the following files:
-	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
-	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
-Proceed? [Y/n]: 
-Created node!
-```
-A final confirmation is still required before the files are created. You can use any number and
-combination of the available command-line options. You will be prompted for the missing values
-through the same interactive process.
+**NOTE:** While using `peekingduck create-node` with `--config_path` is efficient for creating a
+large number of custom nodes, nodes with badly formatted names and types will be skipped
+automatically. If you would like to use `peekingduck create-node` interactively and be prompted to
+fix any ill-formattings, please see the [bonus section](#bonus-using-peekingduck-create-node-interactively)
+for more details.
 
 If you have been following along to this guide, you should expect to see the following directory
 structure:
@@ -348,3 +278,87 @@ for reference.
 **NOTE:**
 
 While running, the CSV file may be empty. This is because the implementation of this CSV logger completes the writing at the end of the instruction.
+
+## Bonus: Using `peekingduck create-node` Interactively
+`peekingduck create-node` can be used interactively to create the template config and script files
+for custom nodes as demonstrated below.
+```
+> peekingduck create-node
+Creating new custom node...
+Enter node directory relative to /path/to/<project_name> [src/custom_nodes]:
+Select node type (input, model, draw, dabble, output): output
+Enter node name [my_custom_node]: csv_writer
+
+Node directory:	/path/to/<project_name>/src/custom_nodes
+Node type:	output
+Node name:	csv_writer
+
+Creating the following files:
+	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
+	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
+Proceed? [Y/n]: 
+Created node!
+```
+
+### Step a: Enter Your Custom Node Parent Directory
+
+```
+Enter node directory relative to /path/to/<project_name> [src/custom_nodes]:
+```
+Enter the path of your custom node directory, ensure the path is relative to `<project_name>`, e.g.
+`src/<custom_folder_name>`. The default value `src/custom_nodes` is used in this guide.
+
+### Step b: Select a Node Type for Your Custom Node
+
+```text
+Select node type (input, model, draw, dabble, output): output
+```
+Select a node type from one of the five node types in PeekingDuck `(input, model, draw, dabble, output)`.
+`output` type is selected in this guide.
+
+### Step c: Enter Your Custom Node Name
+
+```
+Enter node name [my_custom_node]: csv_writer
+```
+Enter a name for your custom node. Some checks are performed in the background to ensure that the
+node name is valid and does not already exist (to prevent existing files from being overwritten).
+The default value is `my_custom_node` but `csv_writer` is used in this guide.
+
+### Step d: Confirm Node Creation
+
+```
+Node directory:	/path/to/<project_name>/src/custom_nodes
+Node type:	output
+Node name:	csv_writer
+
+Creating the following files:
+	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
+	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
+Proceed? [Y/n]: 
+```
+The full paths of the config and script files to be created will be shown for verification. You can
+abort the process by entering `n`. The default value of `y` is selected in this guide.
+
+### Alternative: Use `peekingduck create-node` with Command-line Options
+
+If you would like to speed things up a little and skip the interactive process, the command-line
+options `--node_subdir`, `--node_type`, `--node_name` can be used with `peekingduck create-node`.
+Step 3a-c from above can be replicated with command-line options as demonstrated below.
+```
+> peekingduck create-node --node_subdir src/custom_nodes --node_type output --node_name csv_writer
+Creating new custom node...
+
+Node directory:	/path/to/<project_name>/src/custom_nodes
+Node type:	output
+Node name:	csv_writer
+
+Creating the following files:
+	Config file: /path/to/<project_name>/src/custom_nodes/configs/output/csv_writer.yml
+	Script file: /path/to/<project_name>/src/custom_nodes/output/csv_writer.py
+Proceed? [Y/n]: 
+Created node!
+```
+A final confirmation is still required before the files are created. You can use any number and
+combination of the available command-line options. You will be prompted for the missing values
+through the same interactive process.

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -16,19 +16,25 @@
 CLI functions for PeekingDuck.
 """
 
-import functools
 import logging
 import math
-import re
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import click
 import yaml
 
 from peekingduck import __version__
-from peekingduck.declarative_loader import PEEKINGDUCK_NODE_TYPES
+from peekingduck.declarative_loader import PEEKINGDUCK_NODE_TYPES, DeclarativeLoader
 from peekingduck.runner import Runner
+from peekingduck.utils.create_node_helper import (
+    create_config_and_script_files,
+    ensure_relative_path,
+    ensure_valid_name,
+    ensure_valid_name_partial,
+    get_config_and_script_paths,
+    verify_option,
+)
 from peekingduck.utils.logger import LoggerSetup
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -141,10 +147,19 @@ def run(config_path: str, node_config: str, log_level: str) -> None:
     ),
     required=False,
 )
+@click.option(
+    "--config_path",
+    help=(
+        "List of nodes to parse. Will automatically create the config and script file "
+        "for any custom nodes."
+    ),
+    required=False,
+)
 def create_node(
     node_subdir: Optional[str] = None,
     node_type: Optional[str] = None,
     node_name: Optional[str] = None,
+    config_path: Optional[str] = None,
 ) -> None:
     """Automates the creation of a new custom node.
 
@@ -152,74 +167,61 @@ def create_node(
     specified, users will be prompted them for the values while performing
     checks to ensure value validity.
     """
-    click.secho("Creating new custom node...")
-    project_dir = Path.cwd()
+    project_dir = _get_cwd()
     node_type_choices = click.Choice(PEEKINGDUCK_NODE_TYPES)
 
-    node_subdir = _verify_option(node_subdir, value_proc=_ensure_relative_path)
-    if node_subdir is None:
-        node_subdir = click.prompt(
-            f"Enter node directory relative to {project_dir}",
-            default="src/custom_nodes",
-            value_proc=_ensure_relative_path,
+    if config_path is not None and any(
+        arg is not None for arg in (node_subdir, node_type, node_name)
+    ):
+        raise ValueError(
+            "--config_path cannot be use with --node_subdir, --node_type, or "
+            "--node_name!"
         )
-    node_dir = project_dir / node_subdir
-
-    node_type = _verify_option(
-        node_type, value_proc=click.types.convert_type(node_type_choices)
-    )
-    if node_type is None:
-        node_type = click.prompt("Select node type", type=node_type_choices)
-
-    node_name = _verify_option(
-        node_name, value_proc=_ensure_valid_name_partial(node_dir, node_type)
-    )
-    if node_name is None:
-        node_name = click.prompt(
-            "Enter node name",
-            default="my_custom_node",
-            value_proc=_ensure_valid_name_partial(node_dir, node_type),
-        )
-
-    created_paths = _get_config_and_script_paths(
-        node_dir, ("configs", node_type), node_type, node_name
-    )
-    click.echo(f"\nNode directory:\t{node_dir}")
-    click.echo(f"Node type:\t{node_type}")
-    click.echo(f"Node name:\t{node_name}")
-    click.echo("\nCreating the following files:")
-    click.echo(f"\tConfig file: {created_paths['config']}")
-    click.echo(f"\tScript file: {created_paths['script']}")
-
-    proceed = click.confirm("Proceed?", default=True)
-    if proceed:
-        created_paths["config"].parent.mkdir(parents=True, exist_ok=True)
-        created_paths["script"].parent.mkdir(parents=True, exist_ok=True)
-        template_paths = _get_config_and_script_paths(
-            Path(__file__).resolve().parent,
-            "configs",
-            ("pipeline", "nodes"),
-            "node_template",
-        )
-        with open(template_paths["config"]) as template_file, open(
-            created_paths["config"], "w"
-        ) as outfile:
-            outfile.write(template_file.read())
-        with open(template_paths["script"]) as template_file, open(
-            created_paths["script"], "w"
-        ) as outfile:
-            lines = template_file.readlines()
-            start = -1
-            for i, line in enumerate(lines):
-                if line.startswith('"'):
-                    start = i
-                    break
-            # In case we couldn't find a starting line
-            start = max(0, start)
-            outfile.writelines(lines[start:])
-        click.echo("Created node!")
+    if config_path is not None:
+        _create_nodes_from_config_file(config_path, project_dir, node_type_choices)
     else:
-        click.echo("Aborted!")
+        click.secho("Creating new custom node...")
+        node_subdir = verify_option(node_subdir, value_proc=ensure_relative_path)
+        if node_subdir is None:
+            node_subdir = click.prompt(
+                f"Enter node directory relative to {project_dir}",
+                default="src/custom_nodes",
+                value_proc=ensure_relative_path,
+            )
+        node_dir = project_dir / node_subdir
+
+        node_type = verify_option(
+            node_type, value_proc=click.types.convert_type(node_type_choices)
+        )
+        if node_type is None:
+            node_type = click.prompt("Select node type", type=node_type_choices)
+
+        node_name = verify_option(
+            node_name, value_proc=ensure_valid_name_partial(node_dir, node_type)
+        )
+        if node_name is None:
+            node_name = click.prompt(
+                "Enter node name",
+                default="my_custom_node",
+                value_proc=ensure_valid_name_partial(node_dir, node_type),
+            )
+
+        created_paths = get_config_and_script_paths(
+            node_dir, ("configs", node_type), node_type, node_name
+        )
+        click.echo(f"\nNode directory:\t{node_dir}")
+        click.echo(f"Node type:\t{node_type}")
+        click.echo(f"Node name:\t{node_name}")
+        click.echo("\nCreating the following files:")
+        click.echo(f"\tConfig file: {created_paths['config']}")
+        click.echo(f"\tScript file: {created_paths['script']}")
+
+        proceed = click.confirm("Proceed?", default=True)
+        if proceed:
+            create_config_and_script_files(created_paths)
+            click.echo("Created node!")
+        else:
+            click.echo("Aborted!")
 
 
 @cli.command()
@@ -259,30 +261,53 @@ def nodes(type_name: str = None) -> None:
     click.secho("\n")
 
 
-def _ensure_relative_path(node_subdir: str) -> str:
-    """Checks that the subdir path does not contain parent directory
-    navigator (..), is not absolute, and is not "peekingduck/pipeline/nodes".
-    """
-    pkd_node_subdir = "peekingduck/pipeline/nodes"
-    if ".." in node_subdir:
-        raise click.exceptions.UsageError("Path cannot contain '..'!")
-    if Path(node_subdir).is_absolute():
-        raise click.exceptions.UsageError("Path cannot be absolute!")
-    if node_subdir == pkd_node_subdir:
-        raise click.exceptions.UsageError(f"Path cannot be '{pkd_node_subdir}'!")
-    return node_subdir
+def _create_nodes_from_config_file(
+    config_path: str, project_dir: Path, node_type_choices: click.Choice
+) -> None:
+    """Creates custom nodes declared in the config file."""
+    run_config_path = Path(config_path)
+    if not run_config_path.is_absolute():
+        run_config_path = (project_dir / run_config_path).resolve()
+    if not run_config_path.exists():
+        raise FileNotFoundError(
+            f"Config file '{config_path}' is not found at {run_config_path}!"
+        )
+    logger.info(f"Creating custom nodes declared in {run_config_path}.")
+    # Load run config with DeclarativeLoader to ensure consistency
+    loader = DeclarativeLoader(run_config_path, "None", "src")
+    try:
+        node_subdir = project_dir / "src" / loader.custom_nodes_dir
+    except AttributeError as custom_nodes_no_exist:
+        raise ValueError(
+            f"Config file '{config_path}' does not contain custom nodes!"
+        ) from custom_nodes_no_exist
 
-
-def _ensure_valid_name(node_dir: Path, node_type: str, node_name: str) -> str:
-    if re.match(r"^[a-zA-Z][\w\-]*[^\W_]$", node_name) is None:
-        raise click.exceptions.UsageError("Invalid node name!")
-    if (node_dir / node_type / f"{node_name}.py").exists():
-        raise click.exceptions.UsageError("Node name already exists!")
-    return node_name
-
-
-def _ensure_valid_name_partial(node_dir: Path, node_type: str) -> Callable:
-    return functools.partial(_ensure_valid_name, node_dir, node_type)
+    for node_str, _ in loader.node_list:
+        try:
+            node_subdir, node_type, node_name = node_str.split(".")
+        except ValueError:
+            continue
+        try:
+            # Check node string formatting
+            ensure_relative_path(node_subdir)
+            node_dir = project_dir / "src" / node_subdir
+            click.types.convert_type(node_type_choices)(node_type)
+            ensure_valid_name(node_dir, node_type, node_name)
+        except click.exceptions.UsageError as err:
+            logger.warning(
+                f"{node_str} contains invalid formatting: '{err.message}'. "
+                "Skipping..."
+            )
+            continue
+        created_paths = get_config_and_script_paths(
+            node_dir, ("configs", node_type), node_type, node_name
+        )
+        logger.info(
+            f"Creating files for {node_str}:\n\t"
+            f"Config file: {created_paths['config']}\n\t"
+            f"Script file: {created_paths['script']}"
+        )
+        create_config_and_script_files(created_paths)
 
 
 def _get_cwd() -> Path:
@@ -304,28 +329,6 @@ def _get_node_url(node_type: str, node_name: str) -> str:
     url_postfix = ".html#"
 
     return f"{url_prefix}{node_path}{url_postfix}{node_path}"
-
-
-def _get_config_and_script_paths(
-    parent_dir: Path,
-    config_subdir: Union[str, Tuple[str, ...]],
-    script_subdir: Union[str, Tuple[str, ...]],
-    file_stem: str,
-) -> Dict[str, Path]:
-    """Returns the node config file and its corresponding script file."""
-    if isinstance(config_subdir, tuple):
-        config_subpath = Path(*config_subdir)
-    else:
-        config_subpath = Path(config_subdir)
-    if isinstance(script_subdir, tuple):
-        script_subpath = Path(*script_subdir)
-    else:
-        script_subpath = Path(script_subdir)
-
-    return {
-        "config": parent_dir / config_subpath / f"{file_stem}.yml",
-        "script": parent_dir / script_subpath / f"{file_stem}.py",
-    }
 
 
 def _len_enumerate(item: Tuple) -> int:
@@ -353,30 +356,3 @@ def _num_digits(number: int) -> int:
         (int): Number of digits in the given number.
     """
     return int(math.log10(number))
-
-
-def _verify_option(value: Optional[str], value_proc: Callable) -> Optional[str]:
-    """Verifies that input value via click.option matches the expected value.
-
-    This sets ``value`` to ``None`` if it is invalid so the rest of the prompt
-    can flow smoothly.
-
-    Args:
-        value (Optional[str]): Input value.
-        value_proc (Callable): A function to check the validity of ``value``.
-
-    Returns:
-        (Optional[str]): ``value`` if it is a valid value. ``None`` if it is
-            not.
-
-    Raises:
-        click.exceptions.UsageError: When ``value`` is invalid.
-    """
-    if value is None:
-        return value
-    try:
-        value = value_proc(value)
-    except click.exceptions.UsageError as error:
-        click.echo(f"Error: {error.message}", err=True)
-        value = None
-    return value

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -38,7 +38,7 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     :py:class:`Pipeline <peekingduck.pipeline.pipeline.Pipeline>`.
 
     The declarative loader class creates the specified nodes according to any
-    modfications provided in the configs and returns the pipeline needed for
+    modifications provided in the configs and returns the pipeline needed for
     inference.
 
     Args:

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -22,7 +22,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import yaml
 
@@ -78,22 +78,28 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
 
             self.custom_nodes_dir = custom_nodes_dir
 
-    def _load_node_list(self, run_config_path: Path) -> List[str]:
+    def _load_node_list(self, run_config_path: Path) -> "NodeList":
         """Loads a list of nodes from run_config_path.yml"""
         with open(run_config_path) as node_yml:
-            nodes = yaml.safe_load(node_yml)["nodes"]
+            data = yaml.safe_load(node_yml)
+        if not isinstance(data, dict) or "nodes" not in data:
+            raise ValueError(
+                f"{run_config_path} has an invalid structure. "
+                "Missing top-level 'nodes' key."
+            )
+
+        nodes = data["nodes"]
+        if nodes is None:
+            raise ValueError(f"{run_config_path} does not contain any nodes!")
 
         self.logger.info("Successfully loaded run_config file.")
-        return nodes
+        return NodeList(nodes)
 
     def _get_custom_name_from_node_list(self) -> Any:
         custom_name = None
 
-        for node in self.node_list:
-            if isinstance(node, dict):
-                node_type = [*node][0].split(".")[0]
-            else:
-                node_type = node.split(".")[0]
+        for node_str, _ in self.node_list:
+            node_type = node_str.split(".")[0]
 
             if node_type not in PEEKINGDUCK_NODE_TYPES:
                 custom_name = node_type
@@ -105,16 +111,9 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
         """Given a list of imported nodes, instantiate nodes"""
         instantiated_nodes = []
 
-        for node_item in self.node_list:
-            if isinstance(node_item, dict):
-                # node_str = list(node_item.keys())[0]
-                node_str = next(iter(node_item))
-                config_updates_yml = node_item[node_str]
-            else:
-                node_str = node_item
-                config_updates_yml = None
-
+        for node_str, config_updates_yml in self.node_list:
             node_str_split = node_str.split(".")
+
             self.logger.info(f"Initialising {node_str} node...")
 
             if len(node_str_split) == 3:
@@ -198,3 +197,32 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
         except ValueError as error:
             self.logger.error(str(error))
             sys.exit(1)
+
+
+class NodeList:
+    """Iterator class to return node string and node configs (if any) from the
+    nodes declared in the run config file.
+    """
+
+    def __init__(self, nodes: List[Union[Dict[str, Any], str]]) -> None:
+        self.nodes = nodes
+        self.length = len(nodes)
+
+    def __iter__(self) -> Iterator[Tuple[str, Optional[Dict[str, Any]]]]:
+        self.current = -1
+        return self
+
+    def __next__(self) -> Tuple[str, Optional[Dict[str, Any]]]:
+        self.current += 1
+        if self.current >= self.length:
+            raise StopIteration
+        node_item = self.nodes[self.current]
+
+        if isinstance(node_item, dict):
+            node_str = next(iter(node_item))
+            config_updates = node_item[node_str]
+        else:
+            node_str = node_item
+            config_updates = None
+
+        return node_str, config_updates

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -22,7 +22,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from peekingduck.declarative_loader import DeclarativeLoader
+from peekingduck.declarative_loader import DeclarativeLoader, NodeList
 from peekingduck.pipeline.nodes.node import AbstractNode
 from peekingduck.pipeline.pipeline import Pipeline
 from peekingduck.utils.requirement_checker import RequirementChecker
@@ -111,7 +111,7 @@ class Runner:
             if node.name.endswith(".live") or node.name.endswith(".recorded"):
                 node.release_resources()
 
-    def get_run_config(self) -> List[str]:
+    def get_run_config(self) -> NodeList:
         """Retrieves run configuration.
 
         Returns:

--- a/peekingduck/utils/create_node_helper.py
+++ b/peekingduck/utils/create_node_helper.py
@@ -1,0 +1,133 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for the create node CLI command."""
+
+import functools
+import re
+from pathlib import Path
+from typing import Callable, Dict, Optional, Tuple, Union
+
+import click
+
+
+def create_config_and_script_files(created_paths: Dict[str, Path]) -> None:
+    """Creates a config and script file at the provided paths. The contents of
+    these files will be copied from the template config and script file.
+    """
+    created_paths["config"].parent.mkdir(parents=True, exist_ok=True)
+    created_paths["script"].parent.mkdir(parents=True, exist_ok=True)
+    template_paths = get_config_and_script_paths(
+        Path(__file__).resolve().parents[1],
+        "configs",
+        ("pipeline", "nodes"),
+        "node_template",
+    )
+    with open(template_paths["config"]) as template_file, open(
+        created_paths["config"], "w"
+    ) as outfile:
+        outfile.write(template_file.read())
+    with open(template_paths["script"]) as template_file, open(
+        created_paths["script"], "w"
+    ) as outfile:
+        lines = template_file.readlines()
+        start = -1
+        for i, line in enumerate(lines):
+            if line.startswith('"'):
+                start = i
+                break
+        # In case we couldn't find a starting line
+        start = max(0, start)
+        outfile.writelines(lines[start:])
+
+
+def ensure_relative_path(node_subdir: str) -> str:
+    """Checks that the subdir path does not contain parent directory
+    navigator (..), is not absolute, and is not "peekingduck/pipeline/nodes".
+    """
+    pkd_node_subdir = "peekingduck/pipeline/nodes"
+    if ".." in node_subdir:
+        raise click.exceptions.UsageError("Path cannot contain '..'!")
+    if Path(node_subdir).is_absolute():
+        raise click.exceptions.UsageError("Path cannot be absolute!")
+    if node_subdir == pkd_node_subdir:
+        raise click.exceptions.UsageError(f"Path cannot be '{pkd_node_subdir}'!")
+    return node_subdir
+
+
+def ensure_valid_name(node_dir: Path, node_type: str, node_name: str) -> str:
+    """Checks the validity of the specified node_name. Also checks if it
+    already exists.
+    """
+    if re.match(r"^[a-zA-Z][\w\-]*[^\W_]$", node_name) is None:
+        raise click.exceptions.UsageError("Invalid node name!")
+    if (node_dir / node_type / f"{node_name}.py").exists():
+        raise click.exceptions.UsageError("Node name already exists!")
+    return node_name
+
+
+def ensure_valid_name_partial(node_dir: Path, node_type: str) -> Callable:
+    """Partial function to ensure_valid_name to provide a function that matches
+    function signature required by ``valeu_proc`` in ``click.prompt()``.
+    """
+    return functools.partial(ensure_valid_name, node_dir, node_type)
+
+
+def get_config_and_script_paths(
+    parent_dir: Path,
+    config_subdir: Union[str, Tuple[str, ...]],
+    script_subdir: Union[str, Tuple[str, ...]],
+    file_stem: str,
+) -> Dict[str, Path]:
+    """Returns the node config file and its corresponding script file."""
+    if isinstance(config_subdir, tuple):
+        config_subpath = Path(*config_subdir)
+    else:
+        config_subpath = Path(config_subdir)
+    if isinstance(script_subdir, tuple):
+        script_subpath = Path(*script_subdir)
+    else:
+        script_subpath = Path(script_subdir)
+
+    return {
+        "config": parent_dir / config_subpath / f"{file_stem}.yml",
+        "script": parent_dir / script_subpath / f"{file_stem}.py",
+    }
+
+
+def verify_option(value: Optional[str], value_proc: Callable) -> Optional[str]:
+    """Verifies that input value via click.option matches the expected value.
+
+    This sets ``value`` to ``None`` if it is invalid so the rest of the prompt
+    can flow smoothly.
+
+    Args:
+        value (Optional[str]): Input value.
+        value_proc (Callable): A function to check the validity of ``value``.
+
+    Returns:
+        (Optional[str]): ``value`` if it is a valid value. ``None`` if it is
+            not.
+
+    Raises:
+        click.exceptions.UsageError: When ``value`` is invalid.
+    """
+    if value is None:
+        return value
+    try:
+        value = value_proc(value)
+    except click.exceptions.UsageError as error:
+        click.echo(f"Error: {error.message}", err=True)
+        value = None
+    return value

--- a/peekingduck/utils/create_node_helper.py
+++ b/peekingduck/utils/create_node_helper.py
@@ -79,7 +79,7 @@ def ensure_valid_name(node_dir: Path, node_type: str, node_name: str) -> str:
 
 def ensure_valid_name_partial(node_dir: Path, node_type: str) -> Callable:
     """Partial function to ensure_valid_name to provide a function that matches
-    function signature required by ``valeu_proc`` in ``click.prompt()``.
+    function signature required by ``value_proc`` in ``click.prompt()``.
     """
     return functools.partial(ensure_valid_name, node_dir, node_type)
 

--- a/peekingduck/utils/requirement_checker.py
+++ b/peekingduck/utils/requirement_checker.py
@@ -84,8 +84,7 @@ def check_requirements(
                 pkg.require(req.name)
             except (pkg.DistributionNotFound, pkg.VersionConflict):
                 logger.info(
-                    "%s not found and is required, attempting auto-update...",
-                    req.name,
+                    f"{req.name} not found and is required, attempting auto-update..."
                 )
                 try:
                     logger.info(
@@ -97,22 +96,16 @@ def check_requirements(
                     raise
         else:
             logger.warning(
-                (
-                    "The %s node requires %s which needs to be "
-                    "manually installed. Please follow the instructions "
-                    "at %s and rerun. Ignore this warning if the "
-                    "package is already installed"
-                ),
-                identifier,
-                req.name.strip(),
-                "https://peekingduck.readthedocs.io/en/stable/peekingduck.pipeline.nodes.html",
+                f"The {identifier} node requires {req.name.strip()} which needs to be "
+                "manually installed. Please follow the instructions at "
+                "https://peekingduck.readthedocs.io/en/stable/peekingduck.pipeline.nodes.html "
+                "and rerun. Ignore this warning if the package is already installed"
             )
 
     if n_update > 0:
         logger.warning(
-            "%d package%s updated. Please rerun for the updates to take effect.",
-            n_update,
-            "s" * int(n_update > 1),
+            f"{n_update} package{'s' * int(n_update > 1)} updated. Please rerun for "
+            "the updates to take effect."
         )
 
     return n_update

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -15,9 +15,9 @@
 import io
 import math
 import os
-import subprocess
 import random
 import string
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -56,41 +56,6 @@ YML = dict(nodes=["input.live", "model.yolo", "draw.bbox", "output.screen"])
 NODE_TYPES = ["input", "model", "dabble", "draw", "output"]
 PKD_DIR = Path(__file__).resolve().parents[2] / "peekingduck"
 PKD_CONFIG_DIR = PKD_DIR / "configs"
-PKD_NODES_DIR = PKD_DIR / "pipeline" / "nodes"
-
-with open(
-    PKD_DIR.parent / "tests" / "data" / "user_inputs" / "create_node.yml"
-) as infile:
-    CREATE_NODE_INPUT = yaml.safe_load(infile.read())
-
-
-@pytest.fixture(params=[0, 1])
-def create_node_input_abort(request):
-    # Windows has a different absolute path format
-    bad_paths = "bad_paths_win" if sys.platform == "win32" else "bad_paths"
-    yield (
-        CREATE_NODE_INPUT[bad_paths],
-        CREATE_NODE_INPUT["bad_types"],
-        CREATE_NODE_INPUT["bad_names"],
-        CREATE_NODE_INPUT["good_paths"][request.param],
-        CREATE_NODE_INPUT["good_types"][request.param],
-        CREATE_NODE_INPUT["good_names"][request.param],
-        CREATE_NODE_INPUT["proceed"]["reject"],
-    )
-
-
-@pytest.fixture(params=[0, 1])
-def create_node_input_accept(request):
-    bad_paths = "bad_paths_win" if sys.platform == "win32" else "bad_paths"
-    yield (
-        CREATE_NODE_INPUT[bad_paths],
-        CREATE_NODE_INPUT["bad_types"],
-        CREATE_NODE_INPUT["bad_names"],
-        CREATE_NODE_INPUT["good_paths"][request.param],
-        CREATE_NODE_INPUT["good_types"][request.param],
-        CREATE_NODE_INPUT["good_names"][request.param],
-        CREATE_NODE_INPUT["proceed"]["accept"][request.param],
-    )
 
 
 def available_nodes_msg(type_name=None):
@@ -204,33 +169,19 @@ def parent_dir():
     return Path.cwd().parent
 
 
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def tmp_project_dir():
-    cwd = Path.cwd()
-    (cwd / PROJECT_DIR).mkdir(parents=True)
-    os.chdir(PROJECT_DIR)
-    yield
-    os.chdir(cwd)
-
-
 @pytest.mark.usefixtures("tmp_dir", "tmp_project_dir")
 class TestCli:
-    def test_version(self, runner):
-        result = runner.invoke(cli, ["--version"])
+    def test_version(self):
+        result = CliRunner().invoke(cli, ["--version"])
 
         assert result.exit_code == 0
         # not testing full message as .invoke() sets program name to cli
         # instead of peekingduck
         assert f"version {__version__}" in result.output
 
-    def test_init_default(self, runner, parent_dir, cwd):
+    def test_init_default(self, parent_dir, cwd):
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = runner.invoke(cli, ["init"])
+            result = CliRunner().invoke(cli, ["init"])
 
             assert result.exit_code == 0
             assert (
@@ -243,9 +194,9 @@ class TestCli:
             with open(cwd / RUN_CONFIG_PATH) as infile:
                 TestCase().assertDictEqual(YML, yaml.safe_load(infile))
 
-    def test_init_custom(self, runner, parent_dir, cwd):
+    def test_init_custom(self, parent_dir, cwd):
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 cli, ["init", "--custom_folder_name", CUSTOM_FOLDER_NAME]
             )
             assert result.exit_code == 0
@@ -259,10 +210,10 @@ class TestCli:
             with open(cwd / RUN_CONFIG_PATH) as infile:
                 TestCase().assertDictEqual(YML, yaml.safe_load(infile))
 
-    def test_run_default(self, runner):
+    def test_run_default(self):
         setup()
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = runner.invoke(cli, ["run"])
+            result = CliRunner().invoke(cli, ["run"])
             assert (
                 captured.records[0].getMessage()
                 == "Successfully loaded run_config file."
@@ -271,10 +222,10 @@ class TestCli:
             assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
             assert result.exit_code == 0
 
-    def test_run_custom_path(self, runner):
+    def test_run_custom_path(self):
         setup(True)
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 cli, ["run", "--config_path", CUSTOM_RUN_CONFIG_PATH]
             )
             assert (
@@ -285,7 +236,7 @@ class TestCli:
             assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
             assert result.exit_code == 0
 
-    def test_run_custom_config(self, runner):
+    def test_run_custom_config(self):
         setup()
         node_name = ".".join(PKD_NODE.split(".")[1:])
         config_update_value = "'do_resizing': True"
@@ -293,7 +244,9 @@ class TestCli:
             f"{{'{node_name}': {{'resize': {{ {config_update_value} }} }} }}"
         )
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = runner.invoke(cli, ["run", "--node_config", config_update_cli])
+            result = CliRunner().invoke(
+                cli, ["run", "--node_config", config_update_cli]
+            )
             assert (
                 captured.records[0].getMessage()
                 == "Successfully loaded run_config file."
@@ -306,232 +259,16 @@ class TestCli:
             assert captured.records[3].getMessage() == init_msg(PKD_NODE_2)
             assert result.exit_code == 0
 
-    def test_create_node_abort(self, runner, create_node_input_abort):
-        (
-            bad_paths,
-            bad_types,
-            bad_names,
-            good_path,
-            good_type,
-            good_name,
-            proceed,
-        ) = create_node_input_abort
-        result = runner.invoke(
-            cli,
-            ["create-node"],
-            input=bad_paths
-            + good_path
-            + bad_types
-            + good_type
-            + bad_names
-            + good_name
-            + proceed,
-        )
-        # Count only substring we create so we are unaffected by click changes
-        config_subpath, script_subpath = get_custom_node_subpaths(
-            good_path.strip(), good_type.strip(), good_name.strip()
-        )
-        assert result.output.count("Path cannot") == bad_paths.count("\n")
-        assert result.output.count("invalid choice") == bad_types.count("\n")
-        assert result.output.count("Invalid node name") == bad_names.count("\n")
-        assert result.output.count(config_subpath) == 1
-        assert result.output.count(script_subpath) == 1
-        assert result.output.count("Aborted!") == 1
-
-    def test_create_node_accept(self, runner, create_node_input_accept):
-        (
-            bad_paths,
-            bad_types,
-            bad_names,
-            good_path,
-            good_type,
-            good_name,
-            proceed,
-        ) = create_node_input_accept
-        result = runner.invoke(
-            cli,
-            ["create-node"],
-            input=bad_paths
-            + good_path
-            + bad_types
-            + good_type
-            + bad_names
-            + good_name
-            + proceed,
-        )
-        # Count only substring we create so we are unaffected by click changes
-        config_subpath, script_subpath = get_custom_node_subpaths(
-            good_path.strip(), good_type.strip(), good_name.strip()
-        )
-        assert result.output.count("Path cannot") == bad_paths.count("\n")
-        assert result.output.count("invalid choice") == bad_types.count("\n")
-        assert result.output.count("Invalid node name") == bad_names.count("\n")
-        assert result.output.count(config_subpath) == 1
-        assert result.output.count(script_subpath) == 1
-        assert result.output.count("Created node!") == 1
-
-        node_subdir = good_path.strip()
-        node_type = good_type.strip()
-        node_name = good_name.strip()
-        cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
-        assert config_path.exists()
-        assert script_path.exists()
-
-        with open(config_path) as actual_file, open(
-            PKD_CONFIG_DIR / "node_template.yml"
-        ) as expected_file:
-            assert actual_file.read() == expected_file.read()
-
-        with open(script_path) as actual_file, open(
-            PKD_NODES_DIR / "node_template.py"
-        ) as expected_file:
-            lines = expected_file.readlines()
-            # Ensuring start exists/is valid is not done here since we expect
-            # it to always be valid
-            for i, line in enumerate(lines):
-                if line.startswith('"'):
-                    start = i
-                    break
-            assert actual_file.readlines() == lines[start:]
-
-    def test_create_node_duplicate_node_name(self, runner, create_node_input_accept):
-        _, _, _, good_path, good_type, good_name, proceed = create_node_input_accept
-
-        node_subdir = good_path.strip()
-        node_type = good_type.strip()
-        node_name = good_name.strip()
-        node_name_2 = "available_node_name"
-        name_input = f"{good_name}{node_name_2}\n"
-        setup_custom_node(node_subdir, node_type, node_name)
-        result = runner.invoke(
-            cli,
-            ["create-node"],
-            input=good_path + good_type + name_input + proceed,
-        )
-        # Only check the "Node name exists" message, others are checked by
-        # previous tests.
-        assert result.output.count("Node name already exists!") == 1
-
-        cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name_2}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name_2}.py"
-        assert config_path.exists()
-        assert script_path.exists()
-
-        with open(config_path) as actual_file, open(
-            PKD_CONFIG_DIR / "node_template.yml"
-        ) as expected_file:
-            assert actual_file.read() == expected_file.read()
-
-        with open(script_path) as actual_file, open(
-            PKD_NODES_DIR / "node_template.py"
-        ) as expected_file:
-            lines = expected_file.readlines()
-            for i, line in enumerate(lines):
-                if line.startswith('"'):
-                    start = i
-                    break
-            assert actual_file.readlines() == lines[start:]
-
-    def test_create_node_cli_options_abort(self, runner, create_node_input_abort):
-        (
-            bad_paths,
-            bad_types,
-            bad_names,
-            good_path,
-            good_type,
-            good_name,
-            proceed,
-        ) = create_node_input_abort
-        result = runner.invoke(
-            cli,
-            [
-                "create-node",
-                "--node_subdir",
-                "../some/path",
-                "--node_type",
-                "some type",
-                "--node_name",
-                "some name",
-            ],
-            input=bad_paths
-            + good_path
-            + bad_types
-            + good_type
-            + bad_names
-            + good_name
-            + proceed,
-        )
-        # Count only substring we create so we are unaffected by click changes
-        config_subpath, script_subpath = get_custom_node_subpaths(
-            good_path.strip(), good_type.strip(), good_name.strip()
-        )
-        assert result.output.count("Path cannot") == bad_paths.count("\n") + 1
-        assert result.output.count("invalid choice") == bad_types.count("\n") + 1
-        assert result.output.count("Invalid node name") == bad_names.count("\n") + 1
-        assert result.output.count(config_subpath) == 1
-        assert result.output.count(script_subpath) == 1
-        assert result.output.count("Aborted!") == 1
-
-    def test_create_node_cli_options_accept(self, runner, create_node_input_accept):
-        _, _, _, good_path, good_type, good_name, proceed = create_node_input_accept
-        node_subdir = good_path.strip()
-        node_type = good_type.strip()
-        node_name = good_name.strip()
-        # Creates only using CLI options with minimal user input
-        result = runner.invoke(
-            cli,
-            [
-                "create-node",
-                "--node_subdir",
-                node_subdir,
-                "--node_type",
-                node_type,
-                "--node_name",
-                node_name,
-            ],
-            input=proceed,
-        )
-        config_subpath, script_subpath = get_custom_node_subpaths(
-            node_subdir, node_type, node_name
-        )
-        assert result.output.count(config_subpath) == 1
-        assert result.output.count(script_subpath) == 1
-        assert result.output.count("Created node!") == 1
-
-        cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
-        assert config_path.exists()
-        assert script_path.exists()
-
-        with open(config_path) as actual_file, open(
-            PKD_CONFIG_DIR / "node_template.yml"
-        ) as expected_file:
-            assert actual_file.read() == expected_file.read()
-
-        with open(script_path) as actual_file, open(
-            PKD_NODES_DIR / "node_template.py"
-        ) as expected_file:
-            lines = expected_file.readlines()
-            for i, line in enumerate(lines):
-                if line.startswith('"'):
-                    start = i
-                    break
-            assert actual_file.readlines() == lines[start:]
-
-    def test_nodes_all(self, runner):
-        result = runner.invoke(cli, ["nodes"])
+    def test_nodes_all(self):
+        result = CliRunner().invoke(cli, ["nodes"])
         print(result.exception)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == available_nodes_msg()
 
-    def test_nodes_single(self, runner):
+    def test_nodes_single(self):
         for node_type in NODE_TYPES:
-            result = runner.invoke(cli, ["nodes", node_type])
+            result = CliRunner().invoke(cli, ["nodes", node_type])
             assert result.exit_code == 0
             assert result.output == available_nodes_msg(node_type)
 

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -1,0 +1,285 @@
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from peekingduck.cli import cli
+
+PROJECT_DIR = Path("tmp_dir")
+
+PKD_DIR = Path(__file__).resolve().parents[2] / "peekingduck"
+PKD_CONFIG_DIR = PKD_DIR / "configs"
+PKD_NODES_DIR = PKD_DIR / "pipeline" / "nodes"
+
+with open(
+    PKD_DIR.parent / "tests" / "data" / "user_inputs" / "create_node.yml"
+) as infile:
+    CREATE_NODE_INPUT = yaml.safe_load(infile.read())
+
+
+@pytest.fixture(params=[0, 1])
+def create_node_input_abort(request):
+    # Windows has a different absolute path format
+    bad_paths = "bad_paths_win" if sys.platform == "win32" else "bad_paths"
+    yield (
+        CREATE_NODE_INPUT[bad_paths],
+        CREATE_NODE_INPUT["bad_types"],
+        CREATE_NODE_INPUT["bad_names"],
+        CREATE_NODE_INPUT["good_paths"][request.param],
+        CREATE_NODE_INPUT["good_types"][request.param],
+        CREATE_NODE_INPUT["good_names"][request.param],
+        CREATE_NODE_INPUT["proceed"]["reject"],
+    )
+
+
+@pytest.fixture(params=[0, 1])
+def create_node_input_accept(request):
+    bad_paths = "bad_paths_win" if sys.platform == "win32" else "bad_paths"
+    yield (
+        CREATE_NODE_INPUT[bad_paths],
+        CREATE_NODE_INPUT["bad_types"],
+        CREATE_NODE_INPUT["bad_names"],
+        CREATE_NODE_INPUT["good_paths"][request.param],
+        CREATE_NODE_INPUT["good_types"][request.param],
+        CREATE_NODE_INPUT["good_names"][request.param],
+        CREATE_NODE_INPUT["proceed"]["accept"][request.param],
+    )
+
+
+def get_custom_node_subpaths(node_subdir, node_type, node_name):
+    return (
+        str(Path(node_subdir) / "configs" / node_type / f"{node_name}.yml"),
+        str(Path(node_subdir) / node_type / f"{node_name}.py"),
+    )
+
+
+def setup_custom_node(node_subdir, node_type, node_name):
+    cwd = Path.cwd()
+    config_dir = cwd / node_subdir / "configs" / node_type
+    script_dir = cwd / node_subdir / node_type
+    config_dir.mkdir(parents=True, exist_ok=True)
+    script_dir.mkdir(parents=True, exist_ok=True)
+
+    (config_dir / f"{node_name}.yml").touch()
+    (script_dir / f"{node_name}.py").touch()
+
+
+@pytest.mark.usefixtures("tmp_dir", "tmp_project_dir")
+class TestCliCreateNode:
+    def test_abort(self, create_node_input_abort):
+        (
+            bad_paths,
+            bad_types,
+            bad_names,
+            good_path,
+            good_type,
+            good_name,
+            proceed,
+        ) = create_node_input_abort
+        result = CliRunner().invoke(
+            cli,
+            ["create-node"],
+            input=bad_paths
+            + good_path
+            + bad_types
+            + good_type
+            + bad_names
+            + good_name
+            + proceed,
+        )
+        # Count only substring we create so we are unaffected by click changes
+        config_subpath, script_subpath = get_custom_node_subpaths(
+            good_path.strip(), good_type.strip(), good_name.strip()
+        )
+        assert result.output.count("Path cannot") == bad_paths.count("\n")
+        assert result.output.count("invalid choice") == bad_types.count("\n")
+        assert result.output.count("Invalid node name") == bad_names.count("\n")
+        assert result.output.count(config_subpath) == 1
+        assert result.output.count(script_subpath) == 1
+        assert result.output.count("Aborted!") == 1
+
+    def test_accept(self, create_node_input_accept):
+        (
+            bad_paths,
+            bad_types,
+            bad_names,
+            good_path,
+            good_type,
+            good_name,
+            proceed,
+        ) = create_node_input_accept
+        result = CliRunner().invoke(
+            cli,
+            ["create-node"],
+            input=bad_paths
+            + good_path
+            + bad_types
+            + good_type
+            + bad_names
+            + good_name
+            + proceed,
+        )
+        # Count only substring we create so we are unaffected by click changes
+        config_subpath, script_subpath = get_custom_node_subpaths(
+            good_path.strip(), good_type.strip(), good_name.strip()
+        )
+        assert result.output.count("Path cannot") == bad_paths.count("\n")
+        assert result.output.count("invalid choice") == bad_types.count("\n")
+        assert result.output.count("Invalid node name") == bad_names.count("\n")
+        assert result.output.count(config_subpath) == 1
+        assert result.output.count(script_subpath) == 1
+        assert result.output.count("Created node!") == 1
+
+        node_subdir = good_path.strip()
+        node_type = good_type.strip()
+        node_name = good_name.strip()
+        cwd = Path.cwd()
+        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
+        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
+        assert config_path.exists()
+        assert script_path.exists()
+
+        with open(config_path) as actual_file, open(
+            PKD_CONFIG_DIR / "node_template.yml"
+        ) as expected_file:
+            assert actual_file.read() == expected_file.read()
+
+        with open(script_path) as actual_file, open(
+            PKD_NODES_DIR / "node_template.py"
+        ) as expected_file:
+            lines = expected_file.readlines()
+            # Ensuring start exists/is valid is not done here since we expect
+            # it to always be valid
+            for i, line in enumerate(lines):
+                if line.startswith('"'):
+                    start = i
+                    break
+            assert actual_file.readlines() == lines[start:]
+
+    def test_duplicate_node_name(self, create_node_input_accept):
+        _, _, _, good_path, good_type, good_name, proceed = create_node_input_accept
+
+        node_subdir = good_path.strip()
+        node_type = good_type.strip()
+        node_name = good_name.strip()
+        node_name_2 = "available_node_name"
+        name_input = f"{good_name}{node_name_2}\n"
+        setup_custom_node(node_subdir, node_type, node_name)
+        result = CliRunner().invoke(
+            cli,
+            ["create-node"],
+            input=good_path + good_type + name_input + proceed,
+        )
+        # Only check the "Node name exists" message, others are checked by
+        # previous tests.
+        assert result.output.count("Node name already exists!") == 1
+
+        cwd = Path.cwd()
+        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name_2}.yml"
+        script_path = cwd / node_subdir / node_type / f"{node_name_2}.py"
+        assert config_path.exists()
+        assert script_path.exists()
+
+        with open(config_path) as actual_file, open(
+            PKD_CONFIG_DIR / "node_template.yml"
+        ) as expected_file:
+            assert actual_file.read() == expected_file.read()
+
+        with open(script_path) as actual_file, open(
+            PKD_NODES_DIR / "node_template.py"
+        ) as expected_file:
+            lines = expected_file.readlines()
+            for i, line in enumerate(lines):
+                if line.startswith('"'):
+                    start = i
+                    break
+            assert actual_file.readlines() == lines[start:]
+
+    def test_cli_options_abort(self, create_node_input_abort):
+        (
+            bad_paths,
+            bad_types,
+            bad_names,
+            good_path,
+            good_type,
+            good_name,
+            proceed,
+        ) = create_node_input_abort
+        result = CliRunner().invoke(
+            cli,
+            [
+                "create-node",
+                "--node_subdir",
+                "../some/path",
+                "--node_type",
+                "some type",
+                "--node_name",
+                "some name",
+            ],
+            input=bad_paths
+            + good_path
+            + bad_types
+            + good_type
+            + bad_names
+            + good_name
+            + proceed,
+        )
+        # Count only substring we create so we are unaffected by click changes
+        config_subpath, script_subpath = get_custom_node_subpaths(
+            good_path.strip(), good_type.strip(), good_name.strip()
+        )
+        assert result.output.count("Path cannot") == bad_paths.count("\n") + 1
+        assert result.output.count("invalid choice") == bad_types.count("\n") + 1
+        assert result.output.count("Invalid node name") == bad_names.count("\n") + 1
+        assert result.output.count(config_subpath) == 1
+        assert result.output.count(script_subpath) == 1
+        assert result.output.count("Aborted!") == 1
+
+    def test_cli_options_accept(self, create_node_input_accept):
+        _, _, _, good_path, good_type, good_name, proceed = create_node_input_accept
+        node_subdir = good_path.strip()
+        node_type = good_type.strip()
+        node_name = good_name.strip()
+        # Creates only using CLI options with minimal user input
+        result = CliRunner().invoke(
+            cli,
+            [
+                "create-node",
+                "--node_subdir",
+                node_subdir,
+                "--node_type",
+                node_type,
+                "--node_name",
+                node_name,
+            ],
+            input=proceed,
+        )
+        config_subpath, script_subpath = get_custom_node_subpaths(
+            node_subdir, node_type, node_name
+        )
+        assert result.output.count(config_subpath) == 1
+        assert result.output.count(script_subpath) == 1
+        assert result.output.count("Created node!") == 1
+
+        cwd = Path.cwd()
+        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
+        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
+        assert config_path.exists()
+        assert script_path.exists()
+
+        with open(config_path) as actual_file, open(
+            PKD_CONFIG_DIR / "node_template.yml"
+        ) as expected_file:
+            assert actual_file.read() == expected_file.read()
+
+        with open(script_path) as actual_file, open(
+            PKD_NODES_DIR / "node_template.py"
+        ) as expected_file:
+            lines = expected_file.readlines()
+            for i, line in enumerate(lines):
+                if line.startswith('"'):
+                    start = i
+                    break
+            assert actual_file.readlines() == lines[start:]

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -381,16 +381,13 @@ class TestCliCreateNode:
 
     def test_missing_config_file(self, cwd):
         config_file = "missing_file.yml"
-        config_path = cwd / config_file
         with pytest.raises(FileNotFoundError) as excinfo:
             CliRunner().invoke(
                 cli,
                 ["create-node", "--config_path", config_file],
                 catch_exceptions=False,
             )
-        assert f"Config file '{config_file}' is not found at {config_path}!" == str(
-            excinfo.value
-        )
+        assert f"Config file '{config_file}' is not found at" in str(excinfo.value)
 
     def test_no_custom_nodes(self, cwd):
         """Tests when the config file doesn't contain any custom nodes, so
@@ -505,10 +502,6 @@ class TestCliCreateNode:
         formatting. So all will be skipped.
         """
         node_string = f"{GOOD_SUBDIR}.{GOOD_TYPE}.{GOOD_NAME}"
-        created_config_path = (
-            cwd / "src" / GOOD_SUBDIR / "configs" / GOOD_TYPE / f"{GOOD_NAME}.yml"
-        )
-        created_script_path = cwd / "src" / GOOD_SUBDIR / GOOD_TYPE / f"{GOOD_NAME}.py"
         config_file = "run_config_invalid_custom_node_string.yml"
         default_nodes_only = cwd / config_file
         with open(default_nodes_only, "w") as outfile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,18 @@ def tmp_dir():
     shutil.rmtree(newpath, ignore_errors=True)  # ignore_errors for windows developement
 
 
+@pytest.fixture
+def tmp_project_dir():
+    """To used after `tmp_dir` fixture to simulate that we're in a proper
+    custom PKD project directory
+    """
+    cwd = Path.cwd()
+    (cwd / "tmp_dir").mkdir(parents=True)
+    os.chdir("tmp_dir")
+    yield
+    os.chdir(cwd)
+
+
 @pytest.fixture(params=TEST_HUMAN_IMAGES)
 def test_human_images(request):
     test_img_dir = PKD_DIR.parent / "images" / "testing"

--- a/tests/data/user_configs/create_node.yml
+++ b/tests/data/user_configs/create_node.yml
@@ -1,0 +1,20 @@
+bad_config_paths:
+  - "/custom_nodes"
+bad_config_paths_win:
+  - "C:/custom_nodes"
+bad_config_types:
+  - ddbl
+  - invalid
+bad_config_names:
+  - "n"
+  - "name!"
+  - "nam:e"
+  - "nam/e"
+  - "nam?e"
+  - "nam e"
+  - "124n"
+  - "_name"
+  - "-name"
+  - " name"
+  - "name_"
+  - "name-"

--- a/tests/data/user_inputs/create_node.yml
+++ b/tests/data/user_inputs/create_node.yml
@@ -31,7 +31,7 @@ bad_names: |
   name_
   name-
   name 123
-good_paths: 
+good_paths:
   - "some/other/path\n"
   - "some/path\n"
 good_types:

--- a/tests/loaders/test_declarativeloader.py
+++ b/tests/loaders/test_declarativeloader.py
@@ -146,8 +146,11 @@ class TestDeclarativeLoader:
     def test_loaded_node_list(self, declarativeloader):
         loaded_nodes = declarativeloader.node_list
 
-        for idx, node in enumerate(loaded_nodes):
-            assert node == NODES["nodes"][idx]
+        for idx, (node, config_updates) in enumerate(loaded_nodes):
+            if isinstance(NODES["nodes"][idx], dict):
+                assert {node: config_updates} == NODES["nodes"][idx]
+            else:
+                assert node == NODES["nodes"][idx]
 
     def test_get_custom_name_from_node_list(self, declarativeloader):
         custom_folder_name = declarativeloader._get_custom_name_from_node_list()

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -217,5 +217,5 @@ class TestRunner:
     def test_get_run_config(self, runner):
         node_list = runner.get_run_config()
 
-        for idx, node in enumerate(node_list):
+        for idx, (node, _) in enumerate(node_list):
             assert node == NODES["nodes"][idx]


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/18

**Changes:**
- Add `--config_path` CLI option and its corresponding function argument `config_path` to `create-node` CLI command
- Implement a `NodeList` iterator class which yields `node_str` and `config_updates`. Assigned to the `node_list` member variable of `DeclarativeLoader`. `node_str` (e.g., `custom_nodes.dabble.fps`) is used by `create_node`.
  - Avoid creating member variables specifically for `create-node` CLI


**How it works:**
- The user can pass in a run config file to create the declared custom nodes by using:
  ```
  peekingduck create-node --config_path <path/to/config_file.yml>
  ```
  1. Check that none of the `node_` related CLI options are used, raise `ValueError` if they are. The "create node by parsing config" feature is meant to be non-interactive.
  2. If `config_path` is a relative path, assume it's relative to the CWD where `peekingduck` is invoked. If not found, raise `FileNotFoundError` with the absolute (reconstructed) path of the config file for the user to troubleshoot.
- Parse the config file using `DeclarativeLoader` to ensure the file is parsed consistently.
  - Raises some additional errors when the config file is badly formatted so it's easier for users to troubleshoot
  - Use the presence of the `custom_nodes_dir` attribute in DeclarativeLoader to check if custom nodes are declared in the config file. Raise `ValueError` if the config file has no custom nodes.
    - Avoid changing member from private to public or directly accessing private members
- Split `node_str` by `.` into `node_subdir`, `node_type`, `node_name`, properly declared custom nodes should split to 3 parts, **silently ignore** anything else.
- Verify formatting of `node_subdir`, `node_type`, `node_name` (same functions as interactive mode), **show warning and skip** if there's badly formatted variables
- Print absolute path and create the necessary config and script files

**Sample output:**
```
└─$ peekingduck create-node --config_path run_config_nodes.yml 
2021-12-01 18:47:52 peekingduck.cli  INFO:  Creating custom nodes declared in /home/yier/code/pkd-sample-project/run_config_nodes.yml. 
2021-12-01 18:47:52 peekingduck.declarative_loader  INFO:  Successfully loaded run_config file. 
2021-12-01 18:47:52 peekingduck.cli  WARNING:  custom_nodes.dabble.print_bbox contains invalid formatting: 'Node name already exists!'. Skipping... 
2021-12-01 18:47:52 peekingduck.cli  WARNING:  custom_nodes.dbl.fps contains invalid formatting: 'invalid choice: dbl. (choose from input, model, draw, dabble, output)'. Skipping... 
2021-12-01 18:47:52 peekingduck.cli  INFO:  Creating files for custom_nodes.dabble.adv_tag:
	Config file: /home/yier/code/pkd-sample-project/src/custom_nodes/configs/dabble/adv_tag.yml
	Script file: /home/yier/code/pkd-sample-project/src/custom_nodes/dabble/adv_tag.py 
2021-12-01 18:47:52 peekingduck.cli  INFO:  Creating files for custom_nodes.output.csv_writer:
	Config file: /home/yier/code/pkd-sample-project/src/custom_nodes/configs/output/csv_writer.yml
	Script file: /home/yier/code/pkd-sample-project/src/custom_nodes/output/csv_writer.py 
```
*Note: Location of `NodeList` class, types of errors raised, and behavior when encountering non-custom nodes or badly formatted nodes are up for discussion.*