### PR TITLE
Upgrade OpenCV version

### DIFF
--- a/peekingduck/pipeline/nodes/draw/utils/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/utils/bbox.py
@@ -73,7 +73,7 @@ def draw_bboxes(
 
 def _draw_bbox(
     frame: np.ndarray,
-    bbox: List[float],
+    bbox: np.ndarray,
     image_size: Tuple[int, int],
     colour: Tuple[int, int, int],
     bbox_label: str = None,
@@ -118,7 +118,7 @@ def _draw_label(
     cv2.putText(
         frame,
         bbox_label,
-        (top_left[0], int(top_left[1] - 6)),
+        (top_left[0], top_left[1] - 6),
         FONT_HERSHEY_SIMPLEX,
         NORMAL_FONTSCALE,
         text_colour,
@@ -129,15 +129,15 @@ def _draw_label(
 
 def draw_tags(
     frame: np.ndarray,
-    bboxes: List[List[float]],
+    bboxes: np.ndarray,
     tags: List[str],
     colour: Tuple[int, int, int],
 ) -> None:
     """Draw tags above bboxes.
 
     Args:
-        frame (np.array): image of current frame
-        bboxes (List[List[float]]): bounding box coordinates
+        frame (np.ndarray): image of current frame
+        bboxes (np.ndarray): bounding box coordinates
         tags (List[string]): tag associated with bounding box
         color (Tuple[int, int, int]): color of text
     """
@@ -162,7 +162,7 @@ def _draw_tag(
     )
     bbox_width = btm_right[0] - top_left[0]
     offset = int((bbox_width - text_width) / 2)
-    position = (int(top_left[0] + offset), int(top_left[1] - baseline))
+    position = (top_left[0] + offset, int(top_left[1] - baseline))
     cv2.putText(
         frame, tag, position, FONT_HERSHEY_SIMPLEX, NORMAL_FONTSCALE, colour, VERY_THICK
     )

--- a/peekingduck/pipeline/nodes/draw/utils/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/utils/bbox.py
@@ -108,7 +108,7 @@ def _draw_label(
     cv2.rectangle(
         frame,
         (top_left[0], top_left[1]),
-        (int(top_left[0] + text_width), int(top_left[1] - text_height - baseline)),
+        (top_left[0] + text_width, top_left[1] - text_height - baseline),
         bg_colour,
         FILLED,
     )
@@ -162,7 +162,7 @@ def _draw_tag(
     )
     bbox_width = btm_right[0] - top_left[0]
     offset = int((bbox_width - text_width) / 2)
-    position = (top_left[0] + offset, int(top_left[1] - baseline))
+    position = (top_left[0] + offset, top_left[1] - baseline)
     cv2.putText(
         frame, tag, position, FONT_HERSHEY_SIMPLEX, NORMAL_FONTSCALE, colour, VERY_THICK
     )

--- a/peekingduck/pipeline/nodes/draw/utils/general.py
+++ b/peekingduck/pipeline/nodes/draw/utils/general.py
@@ -59,4 +59,4 @@ def project_points_onto_original_image(
     projected_points[:, 0] *= width
     projected_points[:, 1] *= height
 
-    return projected_points.astype(int)
+    return np.round(projected_points).astype(int)

--- a/peekingduck/pipeline/nodes/draw/utils/general.py
+++ b/peekingduck/pipeline/nodes/draw/utils/general.py
@@ -59,4 +59,4 @@ def project_points_onto_original_image(
     projected_points[:, 0] *= width
     projected_points[:, 1] *= height
 
-    return projected_points
+    return projected_points.astype(int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama == 0.4.4
 numpy == 1.17.3
-opencv-python == 4.1.2.30
+opencv-python >= 4.5.2.54
 pyyaml >= 5.3.1
 requests == 2.24.0
 tensorflow == 2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     pyyaml >= 5.3
     click == 7.1.2
     requests == 2.24
-    opencv-python == 4.1.2.30
+    opencv-python >= 4.5.2.54
     tensorflow >= 2.2
     numpy >= 1.17.3
     tqdm == 4.45.0


### PR DESCRIPTION
Closes #556. 

- `4.5.2.54` chosen due to factors mentioned in the issue.
- unpinned dependency version as a [good practice](https://stackoverflow.com/questions/28509481/should-i-pin-my-python-dependencies-versions) for releasing packages