### PR TITLE
docs: fix directory structure in build custom nodes tutorial

### DIFF
--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -82,9 +82,8 @@ structure:
 │       ├── configs
 │       │   └── output
 │       │       └── csv_writer.yml
-│       └── custom_nodes
-│           └── output
-│               └── csv_writer.py
+│       └── output
+│           └── csv_writer.py
 ├── run_config.yml
 ├── results
 ```


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck/issues/568

Removed the extra `custom_nodes` folder, it should look like this now:
![ksnip_20211229-094802](https://user-images.githubusercontent.com/56420072/147619929-544b6ddb-49d6-459c-9670-c154cf1735ea.png)
