### PR TITLE
Feature: `--num_iter` CLI option to stop pipeline after `num_iter` runs

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -39,8 +39,16 @@ from peekingduck.cli import cli, run
     default="info",
     help="""Modify log level {"critical", "error", "warning", "info", "debug"}""",
 )
+@click.option(
+    "--num_iter",
+    default=None,
+    type=int,
+    help="""Stop pipeline after running this number of iterations""",
+)
 @click.pass_context
-def main(context: click.Context, config_path: str, log_level: str) -> None:
+def main(
+    context: click.Context, config_path: str, log_level: str, num_iter: int
+) -> None:
     """Invokes the run() CLI command with some different defaults for
     ``node_config`` and ``nodes_parent_dir``.
     """
@@ -59,6 +67,7 @@ def main(context: click.Context, config_path: str, log_level: str) -> None:
         config_path=config_path,
         node_config="None",
         log_level=log_level,
+        num_iter=num_iter,
         nodes_parent_dir=nodes_parent_dir,
     )
 

--- a/__main__.py
+++ b/__main__.py
@@ -43,7 +43,7 @@ from peekingduck.cli import cli, run
     "--num_iter",
     default=None,
     type=int,
-    help="""Stop pipeline after running this number of iterations""",
+    help="Stop pipeline after running this number of iterations",
 )
 @click.pass_context
 def main(

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -101,7 +101,7 @@ def init(custom_folder_name: str) -> None:
     "--num_iter",
     default=None,
     type=int,
-    help="""Stop pipeline after running this number of iterations""",
+    help="Stop pipeline after running this number of iterations",
 )
 def run(
     config_path: str,

--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -87,18 +87,28 @@ def init(custom_folder_name: str) -> None:
     ),
 )
 @click.option(
+    "--log_level",
+    default="info",
+    help="""Modify log level {"critical", "error", "warning", "info", "debug"}""",
+)
+@click.option(
     "--node_config",
     default="None",
     help="""Modify node configs by wrapping desired configs in a JSON string.\n
         Example: --node_config '{"node_name": {"param_1": var_1}}'""",
 )
 @click.option(
-    "--log_level",
-    default="info",
-    help="""Modify log level {"critical", "error", "warning", "info", "debug"}""",
+    "--num_iter",
+    default=None,
+    type=int,
+    help="""Stop pipeline after running this number of iterations""",
 )
 def run(
-    config_path: str, node_config: str, log_level: str, nodes_parent_dir: str = "src"
+    config_path: str,
+    log_level: str,
+    node_config: str,
+    num_iter: int,
+    nodes_parent_dir: str = "src",
 ) -> None:
     """Runs PeekingDuck"""
     LoggerSetup.set_log_level(log_level)
@@ -109,7 +119,12 @@ def run(
     else:
         run_config_path = Path(config_path)
 
-    runner = Runner(run_config_path, node_config, nodes_parent_dir)
+    runner = Runner(
+        run_config_path=run_config_path,
+        config_updates_cli=node_config,
+        custom_nodes_parent_subdir=nodes_parent_dir,
+        num_iter=num_iter,
+    )
     runner.run()
 
 

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -49,15 +49,17 @@ class Runner:
             used with PeekingDuck. For more information on using custom nodes,
             please refer to
             `Getting Started <getting_started/03_custom_nodes.html>`_.
+        num_iter (int): Stop pipeline after running this number of iterations
         nodes (:obj:`List[AbstractNode]` | :obj:`None`): If a list of nodes is
             provided, initialize by the node stack directly.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         run_config_path: Path = None,
         config_updates_cli: str = None,
         custom_nodes_parent_subdir: str = None,
+        num_iter: int = None,
         nodes: List[AbstractNode] = None,
     ):
         self.logger = logging.getLogger(__name__)
@@ -82,9 +84,15 @@ class Runner:
             sys.exit(1)
         if RequirementChecker.n_update > 0:
             sys.exit(3)
+        if num_iter:
+            self.logger.info(f"Run pipeline for {num_iter} iterations")
+            self.num_iter = num_iter
+        else:
+            self.num_iter = 0
 
     def run(self) -> None:
         """execute single or continuous inference"""
+        num_iter = 0
         while not self.pipeline.terminate:
             for node in self.pipeline.nodes:
                 if (
@@ -106,6 +114,11 @@ class Runner:
 
                 outputs = node.run(inputs)
                 self.pipeline.data.update(outputs)
+            num_iter += 1
+            if self.num_iter and num_iter >= self.num_iter:
+                self.logger.info(f"Stopping pipeline after {num_iter} iterations")
+                break
+
         # clean up nodes with threads
         for node in self.pipeline.nodes:
             if node.name.endswith(".live") or node.name.endswith(".recorded"):

--- a/peekingduck/runner.py
+++ b/peekingduck/runner.py
@@ -84,11 +84,11 @@ class Runner:
             sys.exit(1)
         if RequirementChecker.n_update > 0:
             sys.exit(3)
-        if num_iter:
-            self.logger.info(f"Run pipeline for {num_iter} iterations")
-            self.num_iter = num_iter
-        else:
+        if num_iter is None or num_iter <= 0:
             self.num_iter = 0
+        else:
+            self.num_iter = num_iter
+            self.logger.info(f"Run pipeline for {num_iter} iterations")
 
     def run(self) -> None:
         """execute single or continuous inference"""
@@ -115,7 +115,7 @@ class Runner:
                 outputs = node.run(inputs)
                 self.pipeline.data.update(outputs)
             num_iter += 1
-            if self.num_iter and num_iter >= self.num_iter:
+            if self.num_iter > 0 and num_iter >= self.num_iter:
                 self.logger.info(f"Stopping pipeline after {num_iter} iterations")
                 break
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -573,12 +573,15 @@ class TestCli:
     def test_num_iter(self):
         setup()
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
-            result = CliRunner().invoke(cli, ["run", "--num_iter", 50])
+            n = 50  # run test for 50 iterations
+            result = CliRunner().invoke(cli, ["run", "--num_iter", n])
             assert (
                 captured.records[0].getMessage()
                 == "Successfully loaded run_config file."
             )
             assert captured.records[1].getMessage() == init_msg(PKD_NODE)
             assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
-            assert captured.records[-1].getMessage() == "Run pipeline for 50 iterations"
+            assert (
+                captured.records[-1].getMessage() == f"Run pipeline for {n} iterations"
+            )
             assert result.exit_code == 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -569,3 +569,16 @@ class TestCli:
         exit_status = proc.returncode
         assert "DEBUG" in out_str
         assert exit_status == 0
+
+    def test_num_iter(self):
+        setup()
+        with TestCase.assertLogs("peekingduck.cli.logger") as captured:
+            result = CliRunner().invoke(cli, ["run", "--num_iter", 50])
+            assert (
+                captured.records[0].getMessage()
+                == "Successfully loaded run_config file."
+            )
+            assert captured.records[1].getMessage() == init_msg(PKD_NODE)
+            assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
+            assert captured.records[-1].getMessage() == "Run pipeline for 50 iterations"
+            assert result.exit_code == 0

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -102,7 +102,10 @@ def runner(request):
         wraps=replace_declarativeloader_get_pipeline,
     ):
         test_runner = Runner(
-            RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, CUSTOM_NODES_DIR, request.param
+            run_config_path=RUN_CONFIG_PATH,
+            config_updates_cli=CONFIG_UPDATES_CLI,
+            custom_nodes_parent_subdir=CUSTOM_NODES_DIR,
+            nodes=request.param,
         )
 
         return test_runner
@@ -134,7 +137,10 @@ def runner_with_nodes(test_input_node, test_node_end):
     setup()
     instantiated_nodes = [test_input_node, test_node_end]
     test_runner = Runner(
-        RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, CUSTOM_NODES_DIR, instantiated_nodes
+        run_config_path=RUN_CONFIG_PATH,
+        config_updates_cli=CONFIG_UPDATES_CLI,
+        custom_nodes_parent_subdir=CUSTOM_NODES_DIR,
+        nodes=instantiated_nodes,
     )
 
     return test_runner
@@ -150,11 +156,13 @@ class TestRunner:
     def test_init_nodes_none_config_updates_none(self, test_input_node):
         print(test_input_node)
         with pytest.raises(SystemExit):
-            Runner(RUN_CONFIG_PATH)
+            Runner(run_config_path=RUN_CONFIG_PATH)
 
     def test_init_nodes_none_custom_nodes_none(self):
         with pytest.raises(SystemExit):
-            Runner(RUN_CONFIG_PATH, CONFIG_UPDATES_CLI)
+            Runner(
+                run_config_path=RUN_CONFIG_PATH, config_updates_cli=CONFIG_UPDATES_CLI
+            )
 
     def test_init_nodes_with_instantiated_nodes(self, runner_with_nodes):
         with mock.patch(
@@ -171,7 +179,10 @@ class TestRunner:
             "peekingduck.pipeline.pipeline.Pipeline.__init__", side_effect=ValueError
         ), pytest.raises(SystemExit):
             Runner(
-                RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, CUSTOM_NODES_DIR, [ground_truth]
+                run_config_path=RUN_CONFIG_PATH,
+                config_updates_cli=CONFIG_UPDATES_CLI,
+                custom_nodes_parent_subdir=CUSTOM_NODES_DIR,
+                nodes=[ground_truth],
             )
 
     def test_init_with_updated_packages(self):
@@ -180,7 +191,11 @@ class TestRunner:
             "peekingduck.declarative_loader.DeclarativeLoader.get_pipeline",
             wraps=get_pipeline_with_default_node_names,
         ), pytest.raises(SystemExit) as exec_info:
-            Runner(RUN_CONFIG_PATH, CONFIG_UPDATES_CLI, CUSTOM_NODES_DIR)
+            Runner(
+                run_config_path=RUN_CONFIG_PATH,
+                config_updates_cli=CONFIG_UPDATES_CLI,
+                custom_nodes_parent_subdir=CUSTOM_NODES_DIR,
+            )
         # Ensure we are throwing the correct exit code
         assert exec_info.value.code == 3
 


### PR DESCRIPTION
[Re-open new PR with refreshed `node-v1.2` codebase]
New CLI option --num_iter to specify number of pipeline iterations. Pipeline run will stop upon reaching this number. If not specified (default behavior), pipeline will run indefinitely until a) the user manually terminates it or b) the input stream is exhausted.

Added this as it helps to have controlled, deterministic pipeline runs when profiling codes or conducting experiments.

Also request to help delete aborted, closed issue #570 (as I am unable to delete it).