### PR TITLE
fix: use opencv-contrib-python so opencv tracker works

### DIFF
--- a/peekingduck/pipeline/nodes/dabble/utils/tracking_files/opencv_tracking.py
+++ b/peekingduck/pipeline/nodes/dabble/utils/tracking_files/opencv_tracking.py
@@ -17,12 +17,14 @@ Tracking algorithm that uses OpenCV's MOSSE.
 """
 
 from typing import Any, Dict, List, Tuple, Union
-import numpy as np
+
 import cv2
+import numpy as np
+
 from peekingduck.pipeline.nodes.dabble.utils.tracking_files.iou_tracker.utils import (
     format_boxes,
+    iou,
 )
-from peekingduck.pipeline.nodes.dabble.utils.tracking_files.iou_tracker.utils import iou
 
 
 class OpenCVTracker:  # pylint: disable=too-few-public-methods
@@ -169,7 +171,7 @@ class OpenCVTracker:  # pylint: disable=too-few-public-methods
             Any: MOSSE Tracker.
         """
         if tracker_type == "MOSSE":
-            tracker = cv2.TrackerMOSSE_create()
+            tracker = cv2.legacy.TrackerMOSSE_create()
         else:
             raise ValueError("Incorrect tracker type.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click == 7.1.2
 colorama == 0.4.4
 numpy == 1.17.3
-opencv-python >= 4.5.2.54
+opencv-contrib-python >= 4.5.2.54
 pyyaml >= 5.3.1
 requests == 2.24.0
 tensorflow == 2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     pyyaml >= 5.3
     click == 7.1.2
     requests == 2.24
-    opencv-python >= 4.5.2.54
+    opencv-contrib-python >= 4.5.2.54
     tensorflow >= 2.2
     numpy >= 1.17.3
     tqdm == 4.45.0


### PR DESCRIPTION
Change dependency to `opencv-contri-python` so OpenCV (mosse) tracker can work.

Although this will be fixed in the MOT evaluation PR, that PR might take some time to pass. So this quick fix allows development on `node-v1.2` branch to continue.