### PR TITLE
Add clean: to makefile for 'make clean'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,12 +2,29 @@
 #
 export READTHEDOCS=1
 
+# Technotes:
+# - exec `make html` from docs/ folder
+# - first run will display a number of warnings (normal behavior)
+# - second and subsequent runs should not display any warnings
+
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+
+# Clean up intermediate system-generated docs for a blank slate
+# NB: need master.rst, so back it up first, then restore
+# clean the working build/ folder
+clean:
+	@echo "clean $(SOURCEDIR) (except master.rst)..."
+	@mv $(SOURCEDIR)/master.rst $(SOURCEDIR)/master.bak
+	@rm -rf $(SOURCEDIR)/*.rst
+	@mv $(SOURCEDIR)/master.bak $(SOURCEDIR)/master.rst
+	@echo "clean $(BUILDDIR)..."
+	@rm -rf $(BUILDDIR)/doctrees
+	@rm -rf $(BUILDDIR)/html
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,8 +2,8 @@
 #
 export READTHEDOCS=1
 
-# Technotes:
-# - exec `make html` from docs/ folder
+# HTML Documentation Technotes:
+# - exec `make html` from docs/ to generate html documentation
 # - first run will display a number of warnings (normal behavior)
 # - second and subsequent runs should not display any warnings
 
@@ -14,14 +14,10 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-# Clean up intermediate system-generated docs for a blank slate
-# NB: need master.rst, so back it up first, then restore
-# clean the working build/ folder
+# Clean up intermediate system-generated docs in source/ and build/
 clean:
-	@echo "clean $(SOURCEDIR) (except master.rst)..."
-	@mv $(SOURCEDIR)/master.rst $(SOURCEDIR)/master.bak
-	@rm -rf $(SOURCEDIR)/*.rst
-	@mv $(SOURCEDIR)/master.bak $(SOURCEDIR)/master.rst
+	@echo "clean $(SOURCEDIR)..."
+	@rm -rf $(SOURCEDIR)/peekingduck*.rst
 	@echo "clean $(BUILDDIR)..."
 	@rm -rf $(BUILDDIR)/doctrees
 	@rm -rf $(BUILDDIR)/html


### PR DESCRIPTION
Updated `docs/Makefile` with a new `clean:` section that removes previously generated `.rst` files in `source/` and clears the `build/` folder.
This allows a `make html` to be done from a clean slate, to eliminate warnings/errors caused by outdated (previously generated) `.rst` files.