### PR TITLE
`dabble.tag_count_over_time` node

### DIFF
--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -55,8 +55,8 @@
 .. |large_groups| replace:: ``large_groups`` (:obj:`List[int]`): A list of integers representing
    the group IDs of groups that have exceeded the size threshold.
 
-.. |obj_tags| replace:: ``obj_tags`` (:obj:`List[str]`): A list of strings to be added to a
-   bounding box for display. The order of the tags follow the order of ``bboxes``.
+.. |obj_tags| replace:: ``obj_tags`` (:obj:`List[str]`): A list of strings representing characteristics
+   of each bounding box. The order of the tags follow the order of ``bboxes``.
 
 .. |zones| replace:: ``zones`` (:obj:`List[List[Tuple[float, ...]]]`): A nested list of
    coordinates, with each sub-list containing the coordinates (x, y) representing the points that

--- a/peekingduck/configs/dabble/tag_count_over_time.yml
+++ b/peekingduck/configs/dabble/tag_count_over_time.yml
@@ -1,0 +1,2 @@
+input: ["obj_tags"]
+output: ["count"]

--- a/peekingduck/pipeline/nodes/dabble/tag_count_over_time.py
+++ b/peekingduck/pipeline/nodes/dabble/tag_count_over_time.py
@@ -1,0 +1,66 @@
+# Copyright 2021 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Counts the number of unique object tags accumulated over time.
+"""
+
+from typing import Any, Dict
+
+from peekingduck.pipeline.nodes.node import AbstractNode
+
+
+class Node(AbstractNode):
+    """Counts the number of unique object tags accumulated over time from object tracking.
+    It assumes that each item within ``obj_tags`` is of type ``str(int)`` and the id of the first
+    ever tag is "0". For example, ["0", "1", "2"] would give a count of 3.
+
+    Inputs:
+        |obj_tags|
+
+    Outputs:
+        |count|
+
+    Configs:
+        None.
+    """
+
+    def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
+        super().__init__(config, node_path=__name__, **kwargs)
+        self.num_tags_over_time = 0
+
+    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Counts the number of unique object tags accumulated over time.
+
+        Args:
+            inputs (Dict): Inputs dictionary with the key `obj_tags`.
+
+        Returns:
+            (Dict): Outputs dictionary with the key `count`.
+        """
+        if not inputs["obj_tags"]:
+            pass
+        else:
+            max_tag_in_frame = max(
+                list(map(_convert_int_increment, inputs["obj_tags"]))
+            )
+            if max_tag_in_frame > self.num_tags_over_time:
+                self.num_tags_over_time = max_tag_in_frame
+
+        return {"count": self.num_tags_over_time}
+
+
+def _convert_int_increment(tag: str) -> int:
+    """Changes type to int and increment by 1 as tag ID begins with 0."""
+    return int(tag) + 1

--- a/tests/pipeline/nodes/dabble/test_tag_count_over_time.py
+++ b/tests/pipeline/nodes/dabble/test_tag_count_over_time.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2021 AI Singapore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from peekingduck.pipeline.nodes.dabble.tag_count_over_time import Node
+
+
+class TestTagCountOverTime:
+    def test_no_tags(self):
+        node = Node({"input": ["obj_tags"], "output": ["count"]})
+        input1 = {"obj_tags": []}
+        node.run(input1)
+        input2 = {"obj_tags": []}
+        assert node.run(input2)["count"] == 0
+
+    def test_increasing_tag_num(self):
+        node = Node({"input": ["obj_tags"], "output": ["count"]})
+        input1 = {"obj_tags": ["0", "1", "2", "3", "4", "5", "6"]}
+        node.run(input1)
+        input2 = {"obj_tags": ["5", "6", "7"]}
+        assert node.run(input2)["count"] == 8
+
+    def test_decreasing_tag_num(self):
+        # Scenario where no new objects to be tracked are introduced,
+        # and some earlier tracked objects have disappeared from frame
+        node = Node({"input": ["obj_tags"], "output": ["count"]})
+        input1 = {"obj_tags": ["0", "1", "2", "3", "4", "5", "6"]}
+        node.run(input1)
+        input2 = {"obj_tags": ["0", "1", "2", "5"]}
+        assert node.run(input2)["count"] == 7
+
+    def test_mixed_tag_order(self):
+        node = Node({"input": ["obj_tags"], "output": ["count"]})
+        input1 = {"obj_tags": ["0", "1", "2", "3", "4", "5", "6"]}
+        node.run(input1)
+        input2 = {"obj_tags": ["5", "2", "6", "0", "7", "1", "4", "3"]}
+        node.run(input2)
+        input3 = {"obj_tags": ["5", "2", "3"]}
+        assert node.run(input3)["count"] == 8
+
+    def test_alternating_empty_nonempty(self):
+        node = Node({"input": ["obj_tags"], "output": ["count"]})
+        input1 = {"obj_tags": []}
+        node.run(input1)
+        input2 = {"obj_tags": ["0"]}
+        node.run(input2)
+        input3 = {"obj_tags": []}
+        node.run(input3)
+        input4 = {"obj_tags": ["0"]}
+        assert node.run(input4)["count"] == 1


### PR DESCRIPTION
closes https://github.com/aimakerspace/PeekingDuck-Private/issues/27.

`model.jde`, `dabble.tracking` returns `["obj_tags"]`, for example:

Frame X: `['0', '1', '2', '3', '4', '5', '6', '7', '8', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '23', '25', '26', '29', '31', '40', '32', '24', '48', '27', '44', '52', '28', '53', '21', '41', '38']`

Frame X+1: `['0', '1', '2', '3', '4', '5', '6', '7', '8', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '23', '25', '26', '29', '31', '40', '32', '24', '27', '44', '52', '28', '53', '41', '54', '55', '38', '42']`

Observations about `["obj_tags"]` over different frames:
1. It's a list of strings, not integers
2. The integer values are unordered within this list
3. The sequence gets moved around between frames, e.g. near the end of Frame X, we have **53**->21->**41**, but near the end of Frame X+1, we have **53**->**41**->...

**Approach 1**: See code snippet below. The downside to this approach is that if we are running this over a long period of time, `tags_over_time` grows bigger and bigger and it will become increasingly computationally expensive to make this comparison for every single video frame.
```
        for tag in inputs["obj_tags"]:
            if tag not in self.tags_over_time:
                self.tags_over_time.append(tag)
        return {"count": len(self.tags_over_time)}
```

**Approach 2** (chosen) is implemented in this PR. It's fast as it doesn't store `tags_over_time`, but only the max "id" to be compared with the current video frame. However, it introduces 2 problems described below.

**Problem A**:
- Approach 2 assumes that the "id" of the first tag is always "0". This is true for MOSSE and IOU, but not for JDE: it begins with "1". We need to standardise this and think about how to standardise for future object tracking implementations as well.


**Problem B**-  if users decide to pair this with their own custom nodes, where `obj_tags` is something like `['a', 'b', 'c', 'd', 'e']`, this implementation would break as something like "a" cannot be converted to `int`.
Possible solutions to this:
1. Leave it as is, as the docstring for this node has explained this 
2. Create a new category of outputs `obj_ids` where the type is `List(int)` instead of `List(str)`, and refactor all object tracking nodes to produce this output. Note that `obj_tags` is of `List(str)` due to nodes such as social distancing where it would return ["TOO CLOSE!", "TOO CLOSE!"]
3. Create a config for this node that can be switched between dealing with `int` vs `str`, switching between Approach 2 and Approach 1 (which can work for `str`). 
4. Just go with Approach 1 and ignore time and space complexity - this would solve Problem A as well. Not recommended.


