### PR TITLE
Fix: failing cli create node tests on M1 Mac

### DIFF
--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -33,6 +33,8 @@ from peekingduck.utils.create_node_helper import (
     ensure_relative_path,
     ensure_valid_name,
     ensure_valid_name_partial,
+    ensure_valid_type,
+    ensure_valid_type_partial,
     get_config_and_script_paths,
     verify_option,
 )
@@ -212,10 +214,13 @@ def create_node(
         node_dir = project_dir / node_subdir
 
         node_type = verify_option(
-            node_type, value_proc=click.types.convert_type(node_type_choices)
+            node_type, value_proc=ensure_valid_type_partial(node_type_choices)
         )
         if node_type is None:
-            node_type = click.prompt("Select node type", type=node_type_choices)
+            node_type = click.prompt(
+                "Select node type",
+                value_proc=ensure_valid_type_partial(node_type_choices),
+            )
 
         node_name = verify_option(
             node_name, value_proc=ensure_valid_name_partial(node_dir, node_type)
@@ -312,7 +317,7 @@ def _create_nodes_from_config_file(
             # Check node string formatting
             ensure_relative_path(node_subdir)
             node_dir = project_dir / "src" / node_subdir
-            click.types.convert_type(node_type_choices)(node_type)
+            ensure_valid_type(node_type_choices, node_type)
             ensure_valid_name(node_dir, node_type, node_name)
         except click.exceptions.UsageError as err:
             logger.warning(

--- a/peekingduck/utils/create_node_helper.py
+++ b/peekingduck/utils/create_node_helper.py
@@ -91,10 +91,10 @@ def ensure_valid_type(node_type_choices: click.Choice, node_type: str) -> str:
     """
     try:
         click.types.convert_type(node_type_choices)(node_type)
-    except click.BadParameter as err:
+    except click.BadParameter:
         raise click.exceptions.UsageError(
             f"'{node_type}' is not one of {', '.join(map(repr, node_type_choices.choices))}."
-        ) from err
+        ) from None
     return node_type
 
 

--- a/peekingduck/utils/create_node_helper.py
+++ b/peekingduck/utils/create_node_helper.py
@@ -84,6 +84,27 @@ def ensure_valid_name_partial(node_dir: Path, node_type: str) -> Callable:
     return functools.partial(ensure_valid_name, node_dir, node_type)
 
 
+def ensure_valid_type(node_type_choices: click.Choice, node_type: str) -> str:
+    """Uses click's convert_type function to check the validity of the
+    specified node_type. Re-raises with a custom error message to ensure
+    consistency across click versions.
+    """
+    try:
+        click.types.convert_type(node_type_choices)(node_type)
+    except click.BadParameter as err:
+        raise click.exceptions.UsageError(
+            f"'{node_type}' is not one of {', '.join(map(repr, node_type_choices.choices))}."
+        ) from err
+    return node_type
+
+
+def ensure_valid_type_partial(node_type_choices: click.Choice) -> Callable:
+    """Partial function to ensure_valid_type to provide a function that matches
+    the function signature required by ``value_proc`` in ``click.prompt()``.
+    """
+    return functools.partial(ensure_valid_type, node_type_choices)
+
+
 def get_config_and_script_paths(
     parent_dir: Path,
     config_subdir: Union[str, Tuple[str, ...]],

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -124,7 +124,7 @@ class TestCliCreateNode:
             good_path.strip(), good_type.strip(), good_name.strip()
         )
         assert result.output.count("Path cannot") == bad_paths.count("\n")
-        assert result.output.count("invalid choice") == bad_types.count("\n")
+        assert result.output.count("is not one of") == bad_types.count("\n")
         assert result.output.count("Invalid node name") == bad_names.count("\n")
         assert result.output.count(config_subpath) == 1
         assert result.output.count(script_subpath) == 1
@@ -156,7 +156,7 @@ class TestCliCreateNode:
             good_path.strip(), good_type.strip(), good_name.strip()
         )
         assert result.output.count("Path cannot") == bad_paths.count("\n")
-        assert result.output.count("invalid choice") == bad_types.count("\n")
+        assert result.output.count("is not one of") == bad_types.count("\n")
         assert result.output.count("Invalid node name") == bad_names.count("\n")
         assert result.output.count(config_subpath) == 1
         assert result.output.count(script_subpath) == 1
@@ -261,7 +261,7 @@ class TestCliCreateNode:
             good_path.strip(), good_type.strip(), good_name.strip()
         )
         assert result.output.count("Path cannot") == bad_paths.count("\n") + 1
-        assert result.output.count("invalid choice") == bad_types.count("\n") + 1
+        assert result.output.count("is not one of") == bad_types.count("\n") + 1
         assert result.output.count("Invalid node name") == bad_names.count("\n") + 1
         assert result.output.count(config_subpath) == 1
         assert result.output.count(script_subpath) == 1
@@ -454,8 +454,10 @@ class TestCliCreateNode:
                 ) == captured.records[offset + counter].getMessage()
                 counter += 1
             for node_string in bad_types:
+                # Invalid type error message begins with a 'user_input' so we
+                # just check for the presence of the double single quote
                 assert (
-                    f"{node_string} contains invalid formatting: 'invalid choice: "
+                    f"{node_string} contains invalid formatting: ''"
                 ) in captured.records[offset + counter].getMessage()
                 counter += 1
             for node_string in bad_names:


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/38

M1 Mac uses a later version of `click` which gives a different error message when user input is not in the predefined `Choice`s.

**Changes**

Re-raise invalid choice error (`BadParameter`) with a custom error message so it remains consistent across `click` versions.