### PR TITLE
Docs: remove extra click to node docs

### DIFF
--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -1,86 +1,4 @@
-.. |img| replace:: ``img`` (:obj:`numpy.ndarray`): A numpy array (height, width, channels)
-   representation of the image, in BGR format
-
-.. |bboxes| replace:: ``bboxes`` (:obj:`numpy.ndarray`): A numpy array (N, 4) containing bounding
-   box information of detected objects. N corresponds to the number of objects detected, and each
-   bounding box is represented as (x1, y1, x2, y2), coordinates (x, y) of the top-left corner and
-   bottom right corner of the bounding box respectively.
-
-.. |bbox_labels| replace:: ``bbox_labels`` (:obj:`numpy.ndarray`): A numpy array (N) of strings,
-   representing the labels of detected objects. The order corresponds to ``bboxes`` and
-   ``bbox_scores``.
-
-.. |bbox_scores| replace:: ``bbox_scores`` (:obj:`numpy.ndarray`): A numpy array (N) of the
-   confidence scores [0, 1] of detected objects. The order corresponds to ``bboxes`` and
-   ``bbox_labels``.
-
-.. |btm_midpoint| replace:: ``btm_midpoint`` (:obj:`List[Tuple[int, int]]`): A list of tuples
-   (x, y) each representing a single point of reference of bounding boxes for use in zone
-   analytics. The order of ``btm_midpoint`` follows the order of ``bboxes``.
-
-.. |count| replace:: ``count`` (:obj:`int`): An integer representing the number of counted objects.
-
-.. |keypoints| replace:: ``keypoints`` (:obj:`numpy.ndarray`): A numpy array (N, K, 2) with the
-   last dimension representing the coordinates (x, y) of detected poses. N represents the number
-   of detected poses, and K represents individual keypoints. Keypoints with low confidence scores
-   (below threshold) will be replaced by ``-1``.
-
-.. |keypoint_scores| replace:: ``keypoint_scores`` (:obj:`numpy.ndarray`): A numpy array (N, K, 1)
-   containing the confidence scores [0, 1] of detected poses. N represents the number of detected
-   poses, and K represents individual keypoints.
-
-.. |keypoint_conns| replace:: ``keypoint_conns`` (:obj:`List[numpy.ndarray]`): A list of N numpy
-   arrays (2, 2) with each array representing one connection in the image. The numpy array contains
-   the coordinates (x, y) of 2 adjacent keypoints pairs, if both keypoints are detected.
-
-.. |pipeline_end| replace:: ``pipeline_end`` (:obj:`bool`): A boolean that evaluates as ``True``
-   when the pipeline is completed. Suitable for operations that require the complete inference
-   pipeline to be completed before running.
-
-.. |filename| replace:: ``filename`` (:obj:`str`): The filename of video/image being read.
-
-.. |fps| replace:: ``fps`` (:obj:`List[float]`): A list of floats representing the FPS per frame.
-   The FPS returned can either be a moving average or an instantaneous value. This setting can be
-   changed in the *configs/dabble/fps* file.
-
-.. |saved_video_fps| replace:: ``saved_video_fps`` (:obj:`float`): FPS of the recorded video, upon
-   filming.
-
-.. |obj_3D_locs| replace:: ``obj_3D_locs`` (:obj:`List[numpy.ndarray]`): A list of N numpy arrays
-   representing the 3D coordinates (x, y, z) of an object associated with a detected bounding box.
-
-.. |obj_groups| replace:: ``obj_groups`` (:obj:`List[int]`): A list of integers representing the
-   assigned group number of an object associated with a detected bounding box.
-
-.. |large_groups| replace:: ``large_groups`` (:obj:`List[int]`): A list of integers representing
-   the group IDs of groups that have exceeded the size threshold.
-
-.. |obj_tags| replace:: ``obj_tags`` (:obj:`List[str]`): A list of strings to be added to a
-   bounding box for display. The order of the tags follow the order of ``bboxes``.
-
-.. |zones| replace:: ``zones`` (:obj:`List[List[Tuple[float, ...]]]`): A nested list of
-   coordinates, with each sub-list containing the coordinates (x, y) representing the points that
-   form the boundaries of a zone. The order of zones follows the order of ``zone_count``.
-
-.. |zone_count| replace:: ``zone_count`` (:obj:`List[int]`): A list of integers representing the
-   count of a pre-selected object (for example, "person") detected in each specified zone. The
-   order of counts follows the order of ``zones``.
-
-.. |density_map| replace:: ``density_map`` (:obj:`numpy.ndarray`): A numpy array that represents
-   the number of persons per pixel. The sum of the array returns the total estimated count of people.
-
-.. |none| replace:: ``none``: No inputs required, or no additional outputs produced.
-   Used for ``input`` nodes that require no prior inputs, or ``draw`` nodes that overwrite current
-   input.
-
-.. |br| raw:: html
-
-   <br />
-
-.. |tab| unicode:: 0xA0 0xA0 0xA0 0xA0
-   :trim:
-
-.. |times|  unicode:: U+000D7 .. MULTIPLICATION SIGN
+.. include:: data_type.rst
 
 {{ fullname | escape | underline }}
 
@@ -91,12 +9,12 @@
    :exclude-members: run
 
 {% block methods -%}
-{% if methods -%}
+   {% if methods -%}
 .. rubric:: Methods
-{% for item in all_methods -%}
-{%- if not item.startswith('_') %}
-   ~{{ name }}.{{ item }}
-{%- endif -%}
-{%- endfor %}
-{% endif -%}
+      {% for item in all_methods -%}
+         {%- if not item.startswith('_') %}
+            ~{{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
+   {% endif -%}
 {% endblock -%}

--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -90,14 +90,13 @@
    :members:
    :exclude-members: run
 
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: Methods
-
-   {% for item in all_methods %}
-      {%- if not item.startswith('_') %}
-      ~{{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+{% block methods -%}
+{% if methods -%}
+.. rubric:: Methods
+{% for item in all_methods -%}
+{%- if not item.startswith('_') %}
+   ~{{ name }}.{{ item }}
+{%- endif -%}
+{%- endfor %}
+{% endif -%}
+{% endblock -%}

--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -1,57 +1,77 @@
-{{ objname | escape | underline }}
+.. include:: data_type.rst
+
+{{ fullname | escape | underline }}
 
 .. rubric:: Description
 
 .. automodule:: {{ fullname }}
 
-{% block modules -%}
-{% if modules -%}
+{% if not fullname.split(".")[-1] in ["dabble", "draw", "input", "model",
+                                      "output", "preprocess"] -%}
+.. autoclass:: {{ fullname }}.Node
+   :members:
+   :exclude-members: run
+
+   {% block methods -%}
+      {% if methods -%}
+.. rubric:: Methods
+         {% for item in all_methods -%}
+            {%- if not item.startswith('_') %}
+               ~{{ name }}.{{ item }}
+            {%- endif -%}
+         {%- endfor %}
+      {% endif -%}
+   {% endblock -%}
+{% else -%}
+   {% block modules -%}
+      {% if modules -%}
 .. rubric:: Modules
 
 .. autosummary::
    :toctree:
    :template: module.rst
    :recursive:
-{% for item in modules %}
-   {{ item }}
-{%- endfor %}
-{% endif -%}
-{% endblock -%}
+         {% for item in modules %}
+            {{ item }}
+         {%- endfor %}
+      {% endif -%}
+   {% endblock -%}
 
-{% block classes -%}
-{% if classes -%}
+   {% block classes -%}
+      {% if classes -%}
 .. rubric:: Classes
 
 .. autosummary::
    :toctree:
    :template: class.rst
-{% for item in classes %}
-   {{ item }}
-{%- endfor %}
+         {% for item in classes %}
+            {{ item }}
+         {%- endfor %}
+      {% endif -%}
+   {% endblock -%}
 {% endif -%}
-{% endblock -%}
 
 {% block functions -%}
-{% if functions -%}
+   {% if functions -%}
 .. rubric:: Functions
 
 .. autosummary::
    :toctree:
-{% for item in functions %}
-   {{ item }}
-{%- endfor %}
-{% endif -%}
+      {% for item in functions %}
+         {{ item }}
+      {%- endfor %}
+   {% endif -%}
 {% endblock -%}
 
 {% block exceptions -%}
-{% if exceptions -%}
+   {% if exceptions -%}
 .. rubric:: Exceptions
 
 .. autosummary::
    :toctree:
    :template: class.rst
-{% for item in exceptions %}
-   {{ item }}
-{%- endfor %}
-{% endif -%}
+      {% for item in exceptions %}
+         {{ item }}
+      {%- endfor %}
+   {% endif -%}
 {% endblock -%}

--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -1,49 +1,11 @@
-{{ fullname | escape | underline }}
+{{ objname | escape | underline }}
 
 .. rubric:: Description
 
 .. automodule:: {{ fullname }}
 
-   {% block functions %}
-   {% if functions %}
-   .. rubric:: Functions
-
-   .. autosummary::
-      :toctree:
-   {% for item in functions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block classes %}
-   {% if classes %}
-   .. rubric:: Classes
-
-   .. autosummary::
-      :toctree:
-      :template: class.rst
-   {% for item in classes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block exceptions %}
-   {% if exceptions %}
-   .. rubric:: Exceptions
-
-   .. autosummary::
-      :toctree:
-      :template: class.rst
-   {% for item in exceptions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-{% block modules %}
-{% if modules %}
+{% block modules -%}
+{% if modules -%}
 .. rubric:: Modules
 
 .. autosummary::
@@ -53,5 +15,43 @@
 {% for item in modules %}
    {{ item }}
 {%- endfor %}
-{% endif %}
-{% endblock %}
+{% endif -%}
+{% endblock -%}
+
+{% block classes -%}
+{% if classes -%}
+.. rubric:: Classes
+
+.. autosummary::
+   :toctree:
+   :template: class.rst
+{% for item in classes %}
+   {{ item }}
+{%- endfor %}
+{% endif -%}
+{% endblock -%}
+
+{% block functions -%}
+{% if functions -%}
+.. rubric:: Functions
+
+.. autosummary::
+   :toctree:
+{% for item in functions %}
+   {{ item }}
+{%- endfor %}
+{% endif -%}
+{% endblock -%}
+
+{% block exceptions -%}
+{% if exceptions -%}
+.. rubric:: Exceptions
+
+.. autosummary::
+   :toctree:
+   :template: class.rst
+{% for item in exceptions %}
+   {{ item }}
+{%- endfor %}
+{% endif -%}
+{% endblock -%}

--- a/docs/source/data_type.rst
+++ b/docs/source/data_type.rst
@@ -1,0 +1,83 @@
+.. |img| replace:: ``img`` (:obj:`numpy.ndarray`): A numpy array (height, width, channels)
+   representation of the image, in BGR format
+
+.. |bboxes| replace:: ``bboxes`` (:obj:`numpy.ndarray`): A numpy array (N, 4) containing bounding
+   box information of detected objects. N corresponds to the number of objects detected, and each
+   bounding box is represented as (x1, y1, x2, y2), coordinates (x, y) of the top-left corner and
+   bottom right corner of the bounding box respectively.
+
+.. |bbox_labels| replace:: ``bbox_labels`` (:obj:`numpy.ndarray`): A numpy array (N) of strings,
+   representing the labels of detected objects. The order corresponds to ``bboxes`` and
+   ``bbox_scores``.
+
+.. |bbox_scores| replace:: ``bbox_scores`` (:obj:`numpy.ndarray`): A numpy array (N) of the
+   confidence scores [0, 1] of detected objects. The order corresponds to ``bboxes`` and
+   ``bbox_labels``.
+
+.. |btm_midpoint| replace:: ``btm_midpoint`` (:obj:`List[Tuple[int, int]]`): A list of tuples
+   (x, y) each representing a single point of reference of bounding boxes for use in zone
+   analytics. The order of ``btm_midpoint`` follows the order of ``bboxes``.
+
+.. |count| replace:: ``count`` (:obj:`int`): An integer representing the number of counted objects.
+
+.. |keypoints| replace:: ``keypoints`` (:obj:`numpy.ndarray`): A numpy array (N, K, 2) with the
+   last dimension representing the coordinates (x, y) of detected poses. N represents the number
+   of detected poses, and K represents individual keypoints. Keypoints with low confidence scores
+   (below threshold) will be replaced by ``-1``.
+
+.. |keypoint_scores| replace:: ``keypoint_scores`` (:obj:`numpy.ndarray`): A numpy array (N, K, 1)
+   containing the confidence scores [0, 1] of detected poses. N represents the number of detected
+   poses, and K represents individual keypoints.
+
+.. |keypoint_conns| replace:: ``keypoint_conns`` (:obj:`List[numpy.ndarray]`): A list of N numpy
+   arrays (2, 2) with each array representing one connection in the image. The numpy array contains
+   the coordinates (x, y) of 2 adjacent keypoints pairs, if both keypoints are detected.
+
+.. |pipeline_end| replace:: ``pipeline_end`` (:obj:`bool`): A boolean that evaluates as ``True``
+   when the pipeline is completed. Suitable for operations that require the complete inference
+   pipeline to be completed before running.
+
+.. |filename| replace:: ``filename`` (:obj:`str`): The filename of video/image being read.
+
+.. |fps| replace:: ``fps`` (:obj:`List[float]`): A list of floats representing the FPS per frame.
+   The FPS returned can either be a moving average or an instantaneous value. This setting can be
+   changed in the *configs/dabble/fps* file.
+
+.. |saved_video_fps| replace:: ``saved_video_fps`` (:obj:`float`): FPS of the recorded video, upon
+   filming.
+
+.. |obj_3D_locs| replace:: ``obj_3D_locs`` (:obj:`List[numpy.ndarray]`): A list of N numpy arrays
+   representing the 3D coordinates (x, y, z) of an object associated with a detected bounding box.
+
+.. |obj_groups| replace:: ``obj_groups`` (:obj:`List[int]`): A list of integers representing the
+   assigned group number of an object associated with a detected bounding box.
+
+.. |large_groups| replace:: ``large_groups`` (:obj:`List[int]`): A list of integers representing
+   the group IDs of groups that have exceeded the size threshold.
+
+.. |obj_tags| replace:: ``obj_tags`` (:obj:`List[str]`): A list of strings to be added to a
+   bounding box for display. The order of the tags follow the order of ``bboxes``.
+
+.. |zones| replace:: ``zones`` (:obj:`List[List[Tuple[float, ...]]]`): A nested list of
+   coordinates, with each sub-list containing the coordinates (x, y) representing the points that
+   form the boundaries of a zone. The order of zones follows the order of ``zone_count``.
+
+.. |zone_count| replace:: ``zone_count`` (:obj:`List[int]`): A list of integers representing the
+   count of a pre-selected object (for example, "person") detected in each specified zone. The
+   order of counts follows the order of ``zones``.
+
+.. |density_map| replace:: ``density_map`` (:obj:`numpy.ndarray`): A numpy array that represents
+   the number of persons per pixel. The sum of the array returns the total estimated count of people.
+
+.. |none| replace:: ``none``: No inputs required, or no additional outputs produced.
+   Used for ``input`` nodes that require no prior inputs, or ``draw`` nodes that overwrite current
+   input.
+
+.. |br| raw:: html
+
+   <br />
+
+.. |tab| unicode:: 0xA0 0xA0 0xA0 0xA0
+   :trim:
+
+.. |times|  unicode:: U+000D7 .. MULTIPLICATION SIGN

--- a/docs/source/getting_started/02_configure_pkdk.md
+++ b/docs/source/getting_started/02_configure_pkdk.md
@@ -4,10 +4,12 @@ This page will guide users on how to control and configure how PeekingDuck behav
 - Selecting which nodes to include in the pipeline
 - Configuring node behaviour
 
-You can refer to our [API Documentation](/peekingduck.pipeline.nodes) section to see the available nodes in PeekingDuck for selection and their respective configurable settings. Alternatively, to get a quick overview of Peekingduck's nodes, run the following command: 
- ```
- > peekingduck nodes
- ```
+```{eval-rst}
+You can refer to our :ref:`API Documentation <api_doc>` section to see the available nodes in PeekingDuck for selection and their respective configurable settings. Alternatively, to get a quick overview of Peekingduck's nodes, run the following command: 
+```
+```
+> peekingduck nodes
+```
 
 In this guide, we will make changes to PeekingDuck config files to run pose estimation models. We will also teach users how to make changes to the default configurations to run a bird detection pipeline on a local video file.
 
@@ -93,4 +95,6 @@ Regardless of the method you choose to configure PeekingDuck, the processed file
 
 ## PeekingDuck API Reference
 We have highlighted the basic configurations for different nodes that you may wish to use for your project.
-To find out what other settings can be tweaked for different nodes, check out the individual node configurations in PeekingDuck's [API Reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+To find out what other settings can be tweaked for different nodes, check out the individual node configurations in PeekingDuck's :ref:`API Documentation <api_doc>`.
+```

--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -2,7 +2,7 @@
 
 You may need to create your own custom nodes. Perhaps you'd like to take a snapshot of a video frame, and post it to your API endpoint; perhaps you have a model trained on a custom dataset, and would like to use PeekingDuck's input, draw, and output nodes. We've designed PeekingDuck to be very flexible --- you can create your own nodes and use them with ours. This guide will showcase how anyone can develop custom nodes to be used with PeekingDuck.
 
-In this guide, we'll be building a custom `csv_writer` node which writes data into a file. It serves as a data collection step that stores useful metrics into a CSV file. This CSV file can be used for logging purposes and can serve as a base for data analytics. (PeekingDuck already has an [`output.csv_writer`](/peekingduck.pipeline.nodes.output.csv_writer.Node) node, but this is a good example for users to experience creating a custom node from scratch.)
+In this guide, we'll be building a custom `csv_writer` node which writes data into a file. It serves as a data collection step that stores useful metrics into a CSV file. This CSV file can be used for logging purposes and can serve as a base for data analytics. (PeekingDuck already has an [`output.csv_writer`](/peekingduck.pipeline.nodes.output.csv_writer) node, but this is a good example for users to experience creating a custom node from scratch.)
 
 A step by step instruction to build this custom node is provided below.
 

--- a/docs/source/getting_started/04_import_peekingduck.md
+++ b/docs/source/getting_started/04_import_peekingduck.md
@@ -14,7 +14,9 @@ Here are some examples where you might want to import PeekingDuck as a module:
 To understand the building blocks, refer to the Introduction [here.](../index.md#how-peekingduck-works)
 
 
-You may also refer to our API Reference to understand PeekingDuck's capabilities [here](/peekingduck.pipeline.nodes).
+```{eval-rst}
+You may also refer to our :ref:`API Documentation <api_doc>` to understand PeekingDuck's capabilities.
+```
 
 Running it in your python scripts can be simple:
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -27,7 +27,9 @@ A **pipeline** governs the behavior of a chain of nodes. The diagram below shows
 
 The rest of this webpage contains more details about using PeekingDuck, including information on:
 - [Changing PeekingDuck nodes](getting_started/02_configure_pkdk) and their settings
-- [Official documentation](/peekingduck.pipeline.nodes) for all PeekingDuck nodes, describing their behaviour, inputs, outputs and settings
+```{eval-rst}
+- :ref:`API Documentation <api_doc>` for all PeekingDuck nodes, describing their behaviour, inputs, outputs and settings
+```
 - Creating your own [custom nodes](getting_started/03_custom_nodes), and using them with PeekingDuck nodes
 - Using PeekingDuck as an [imported Python module](getting_started/04_import_peekingduck) within your project
 - Benchmarks and class/keypoints IDs for [object detection](resources/01a_object_detection) and [pose estimation](resources/01b_pose_estimation) models.
@@ -56,7 +58,9 @@ AI models are cool and fun, but we're even more interested to use them to solve 
 |                                                              |                                                              |
 
 
-We're constantly developing new nodes to increase PeekingDuck's capabilities. You've gotten a taste of some of our commonly used nodes in the previous demos, but PeekingDuck can do a lot more. To see what other nodes are available, check out PeekingDuck's [API Reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+We're constantly developing new nodes to increase PeekingDuck's capabilities. You've gotten a taste of some of our commonly used nodes in the previous demos, but PeekingDuck can do a lot more. To see what other nodes are available, check out PeekingDuck's :ref:`API Documentation <api_doc>`.
+```
 
 
 ## Acknowledgements

--- a/docs/source/master.rst
+++ b/docs/source/master.rst
@@ -23,7 +23,6 @@ API Documentation
    :template: module.rst
    :recursive:
 
-   peekingduck
    peekingduck.pipeline.nodes.input
    peekingduck.pipeline.nodes.preprocess
    peekingduck.pipeline.nodes.model

--- a/docs/source/master.rst
+++ b/docs/source/master.rst
@@ -14,6 +14,8 @@ Welcome to PeekingDuck's documentation!
    resources/index
    use_cases/index
 
+.. _api_doc:
+
 API Documentation
 =================
 

--- a/docs/source/master.rst
+++ b/docs/source/master.rst
@@ -14,9 +14,8 @@ Welcome to PeekingDuck's documentation!
    resources/index
    use_cases/index
 
-Nodes
-=====================================
-Nodes are the core of PeekingDuck. See below for the readily-available nodes and their references.
+API Documentation
+=================
 
 .. autosummary::
    :toctree:

--- a/docs/source/use_cases/crowd_counting.md
+++ b/docs/source/use_cases/crowd_counting.md
@@ -22,7 +22,7 @@ There are two main components to our solution: 1) crowd counting; and 2) heat ma
 
 **1. Crowd Counting**
 
-We use an open source crowd counting model known as [CSRNet](https://arxiv.org/pdf/1802.10062.pdf) to predict the number of people in a sparse or dense crowd. By default, the solution uses the sparse crowd model and this can be changed to the dense crowd model if required. The dense and sparse crowd models were trained using data from ShanghaiTech Part A and ShanghaiTech Part B respectively. As a guideline, you might want to use the dense crowd model if the people in a given image or video frame are packed shoulder to shoulder (e.g. stadiums). For more information on how adjust the CSRNet node, checkout the [CSRNet configurable parameters](/peekingduck.pipeline.nodes.model.csrnet.Node). 
+We use an open source crowd counting model known as [CSRNet](https://arxiv.org/pdf/1802.10062.pdf) to predict the number of people in a sparse or dense crowd. By default, the solution uses the sparse crowd model and this can be changed to the dense crowd model if required. The dense and sparse crowd models were trained using data from ShanghaiTech Part A and ShanghaiTech Part B respectively. As a guideline, you might want to use the dense crowd model if the people in a given image or video frame are packed shoulder to shoulder (e.g. stadiums). For more information on how adjust the CSRNet node, checkout the [CSRNet configurable parameters](/peekingduck.pipeline.nodes.model.csrnet). 
 
 **2. Heat Map Generation (Optional)**
 
@@ -43,7 +43,7 @@ nodes:
 ```
 
 **1. Crowd Counting Node**
-As mentioned, we use CSRNet to estimate the size of a crowd. As the models were trained to recognise congested scenes, the estimates are less accurate if the number of people are low (e.g. less than 10). In such scenarios, you should consider using an object detection model such as the [YOLOX model](/peekingduck.pipeline.nodes.model.yolox.Node) that is included in our repo.
+As mentioned, we use CSRNet to estimate the size of a crowd. As the models were trained to recognise congested scenes, the estimates are less accurate if the number of people are low (e.g. less than 10). In such scenarios, you should consider using an object detection model such as the [YOLOX model](/peekingduck.pipeline.nodes.model.yolox) that is included in our repo.
 
 **2. Heat Map Generation Node (Optional)**
 The heat map generation node superimposes a heat map over a given image or video frame.

--- a/docs/source/use_cases/face_mask_detection.md
+++ b/docs/source/use_cases/face_mask_detection.md
@@ -24,7 +24,7 @@ The main component is the detection of face mask using the custom YOLOv4 model.
 
 We use an open source object detection model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of human faces with and without face masks. This allows the application to identify the locations of faces and their corresponding classes (no_mask = 0 or mask = 1) in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected.
 
-The `yolo_face` node detects human faces with and without face masks using the YOLOv4-tiny model by default. The classes are differentiated by the labels and the colours of the bounding boxes when multiple faces are detected. For more information on how adjust the `yolo_face` node, checkout the [`yolo_face` configurable parameters](/peekingduck.pipeline.nodes.model.yolo_face.Node).
+The `yolo_face` node detects human faces with and without face masks using the YOLOv4-tiny model by default. The classes are differentiated by the labels and the colours of the bounding boxes when multiple faces are detected. For more information on how adjust the `yolo_face` node, checkout the [`yolo_face` configurable parameters](/peekingduck.pipeline.nodes.model.yolo_face).
 
 ## Nodes Used
 
@@ -42,7 +42,7 @@ nodes:
 
 **1. Face Mask Detection Node**
 
-By default, the node uses the YOLOv4-tiny model for face detection. For better accuracy, you can try the [YOLOv4 model](/peekingduck.pipeline.nodes.model.yolo_face.Node) that is included in our repo.
+By default, the node uses the YOLOv4-tiny model for face detection. For better accuracy, you can try the [YOLOv4 model](/peekingduck.pipeline.nodes.model.yolo_face) that is included in our repo.
 
 **2. Adjusting Nodes**
 

--- a/docs/source/use_cases/group_size_checking.md
+++ b/docs/source/use_cases/group_size_checking.md
@@ -79,7 +79,9 @@ Some common node behaviours that you might need to adjust are:
 - `obj_dist_thres`: The maximum distance between 2 individuals, in metres, before they are considered to be part of a group.
 - `group_size_thres`: The acceptable group size limit.
 
-For more adjustable node behaviours not listed here, check out the [API reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.
+```
 
 **3. Using Object Detection (Optional)**
 

--- a/docs/source/use_cases/human_tracking.md
+++ b/docs/source/use_cases/human_tracking.md
@@ -22,7 +22,7 @@ There are two main components to this MOT: 1) human target detection using AI; a
 
 **1. Human Detection**
 
-We use an open source detection model trained on pedestrian detection and person search datasets known as [JDE](https://arxiv.org/abs/1909.12605) to identify human persons. This allows the application to identify the locations of human persons in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human person detected. For more information on how adjust the JDE node, checkout the [JDE configurable parameters](/peekingduck.pipeline.nodes.model.jde.Node).
+We use an open source detection model trained on pedestrian detection and person search datasets known as [JDE](https://arxiv.org/abs/1909.12605) to identify human persons. This allows the application to identify the locations of human persons in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human person detected. For more information on how adjust the JDE node, checkout the [JDE configurable parameters](/peekingduck.pipeline.nodes.model.jde).
 
 **2. Appearance Embedding Tracking**
 

--- a/docs/source/use_cases/multi_object_tracking.md
+++ b/docs/source/use_cases/multi_object_tracking.md
@@ -75,7 +75,9 @@ Some common node behaviours that you might need to adjust are:
 - `detect_ids`: Object class IDs to be detected. View this [link](https://peekingduck.readthedocs.io/en/stable/resources/02_model_indices.html) for each class' indices.
 - `tracking_type`: The type of tracking to be used, choose one of: [iou, mosse]
 
-For more adjustable node behaviours not listed here, check out the [API reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.
+```
 
 ## Tracking Analysis
 

--- a/docs/source/use_cases/object_counting.md
+++ b/docs/source/use_cases/object_counting.md
@@ -22,7 +22,7 @@ The main component to obtain the count is the detections from the object detecti
 
 **1. Object Detection**
 
-We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo.Node).
+We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo).
 
 <img src="https://raw.githubusercontent.com/aimakerspace/PeekingDuck/dev/images/readme/yolo_demo.gif" width="70%">
 
@@ -55,9 +55,11 @@ The object counting node is called by including `dabble.bbox_count` in the run c
 
 **3. Adjusting Nodes**
 
-The object counting node does not have changeable configurations. However, it depends on the configuration set in the object detection models, such as the type of object to detect, etc. For object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo.Node) for adjustable behaviours that can influence the result of the object counting node.
+The object counting node does not have changeable configurations. However, it depends on the configuration set in the object detection models, such as the type of object to detect, etc. For object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo) for adjustable behaviours that can influence the result of the object counting node.
 
-For more adjustable node behaviours not listed here, check out the [API Reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.
+```
 
 ## More Complex Counting Behaviour
 

--- a/docs/source/use_cases/privacy_protection_faces.md
+++ b/docs/source/use_cases/privacy_protection_faces.md
@@ -22,7 +22,7 @@ There are two main components to face anonymisation: 1) face detection using AI;
 
 **1. Face Detection**
 
-We use an open source face detection model known as [MTCNN](https://arxiv.org/abs/1604.02878) to identify human faces. This allows the application to identify the locations of human faces in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected. For more information on how adjust the MTCNN node, checkout the [MTCNN configurable parameters](/peekingduck.pipeline.nodes.model.mtcnn.Node).
+We use an open source face detection model known as [MTCNN](https://arxiv.org/abs/1604.02878) to identify human faces. This allows the application to identify the locations of human faces in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected. For more information on how adjust the MTCNN node, checkout the [MTCNN configurable parameters](/peekingduck.pipeline.nodes.model.mtcnn).
 
 **2. Face De-Identification**
 

--- a/docs/source/use_cases/privacy_protection_license_plate.md
+++ b/docs/source/use_cases/privacy_protection_license_plate.md
@@ -22,7 +22,7 @@ There are two main components to license plate anonymisation: 1) license plate d
 
 **1. License Plate Detection**
 
-We use open-source object detection models under the [YOLOv4](https://arxiv.org/abs/2004.10934) family to identify the locations of the license plates in an image/video feed. Specifically, we offer the YOLOv4-tiny model, which is faster, and the YOLOv4 model, which provides higher accuracy. The locations of detected license plates are returned as an array of coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each license plate detected. For more information on how to adjust the license plate detector node, check out the [license plate detector configurable parameters](/peekingduck.pipeline.nodes.model.yolo_license_plate.Node).
+We use open-source object detection models under the [YOLOv4](https://arxiv.org/abs/2004.10934) family to identify the locations of the license plates in an image/video feed. Specifically, we offer the YOLOv4-tiny model, which is faster, and the YOLOv4 model, which provides higher accuracy. The locations of detected license plates are returned as an array of coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each license plate detected. For more information on how to adjust the license plate detector node, check out the [license plate detector configurable parameters](/peekingduck.pipeline.nodes.model.yolo_license_plate).
 
 **2. License Plate De-Identification**
 

--- a/docs/source/use_cases/social_distancing.md
+++ b/docs/source/use_cases/social_distancing.md
@@ -75,7 +75,9 @@ Some common node behaviours that you might need to adjust are:
 - `tag_msg`: The message to show when individuals are too close.
 - `near_threshold`: The minimum acceptable distance between 2 individuals, in metres. For example, if the threshold is set at 1.5m, and 2 individuals are standing 2.0m apart, `tag_msg` doesn't show as they are standing further apart than the threshold. The larger this number, the stricter the social distancing.
 
-For more adjustable node behaviours not listed here, check out the [API Reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.
+```
 
 **3. Using Object Detection (Optional)**
 

--- a/docs/source/use_cases/zone_counting.md
+++ b/docs/source/use_cases/zone_counting.md
@@ -25,7 +25,7 @@ There are three main components to obtain the zone counts:
 
 **1. Object Detection**
 
-We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo.Node).
+We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo).
 
 <img src="https://raw.githubusercontent.com/aimakerspace/PeekingDuck/dev/images/readme/yolo_demo.gif" width="70%">
 
@@ -95,10 +95,12 @@ The zone counting node is called by including `dabble.zone_count` in the run con
 
 **4. Adjusting Nodes**
 
-The zone counting detections depend on the configuration set in the object detection models, such as the type of object to detect, etc. For the object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo.Node) for adjustable behaviours that can influence the result of the zone counting node.
+The zone counting detections depend on the configuration set in the object detection models, such as the type of object to detect, etc. For the object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo) for adjustable behaviours that can influence the result of the zone counting node.
 
 With regards to the zone counting node, some common node behaviours for the zone counting node that you might need to adjust are:
 - `resolution`: If you are planning to use fractions to set the coordinates for the area of the zone, the resolution should be set to the image/video/livestream resolution used.
 - `zones`: Used to specify the different zones which you would like to set. Each zone coordinates should be set clock-wise in a list. See section on [nodes used](#nodes-used) on how to properly configure multiple zones.
 
-For more adjustable node behaviours not listed here, check out the [API Reference](/peekingduck.pipeline.nodes).
+```{eval-rst}
+For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.
+```


### PR DESCRIPTION
Addresses https://github.com/aimakerspace/PeekingDuck-Private/issues/47

Removes the "extra" single entry class table, effectively reducing the number of clicks needed to get to the actual `Node` documentation.

Removed the more generic `peekingduck` API documentation, only show node related documentation.

Update references in various documents to point to the correct place. Since `peekingduck` API doc is removed, `peekingduck.pipeline.nodes` is replaced with a `_api_doc` anchor in `master.rst`. Added `{eval-rst}` to the affected lines in `.md` files so that the `:ref:` works properly.

Moved data type substitution to a separate file `docs/source/data_type.rst`.

NOTE: Made no attempt to beautify/format `.md` files since they will be converted to `.rst` later. Only made sure no references are broken.

NOTE: The code to check if we should skip directly to `Node` docs is ugly because custom filters in jinja2 is unavailable https://github.com/readthedocs/sphinx-autoapi/issues/200. We can potentially revisit this to refactor it if the features becomes available.