### PR TITLE
docs: shorten module names in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,5 +151,6 @@ build/
 dist/
 peekingduck.egg-info/
 docs/source/peekingduck.*
+docs/source/nodes
 # Other likely files that should not be committed
 .DS_Store

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,6 +18,7 @@ BUILDDIR      = build
 clean:
 	@echo "clean $(SOURCEDIR)..."
 	@rm -rf $(SOURCEDIR)/peekingduck*.rst
+	@rm -rf $(SOURCEDIR)/nodes
 	@echo "clean $(BUILDDIR)..."
 	@rm -rf $(BUILDDIR)/doctrees
 	@rm -rf $(BUILDDIR)/html

--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -6,7 +6,8 @@
 
 .. automodule:: {{ fullname }}
 
-{% if not fullname.split(".")[-1] in ["dabble", "draw", "input", "model", "output", "preprocess"] -%}
+{% if not fullname.split(".")[-1] in ["dabble", "draw", "input", "model",
+                                      "output", "preprocess"] -%}
 .. autoclass:: {{ fullname }}.Node
    :members:
    :exclude-members: run

--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -1,4 +1,4 @@
-.. include:: data_type.rst
+.. include:: ../data_type.rst
 
 {{ fullname | escape | underline }}
 
@@ -6,8 +6,7 @@
 
 .. automodule:: {{ fullname }}
 
-{% if not fullname.split(".")[-1] in ["dabble", "draw", "input", "model",
-                                      "output", "preprocess"] -%}
+{% if not fullname.split(".")[-1] in ["dabble", "draw", "input", "model", "output", "preprocess"] -%}
 .. autoclass:: {{ fullname }}.Node
    :members:
    :exclude-members: run

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath("../../peekingduck/pipeline/nodes"))
 
 
 # -- Project information -----------------------------------------------------
@@ -47,7 +48,7 @@ napoleon_custom_sections = [
     ("Outputs", "returns_style"),
 ]
 
-
+add_module_names = False
 autosummary_generate = True
 master_doc = "master"
 
@@ -76,22 +77,21 @@ html_sidebars = {"**": ["globaltoc.html", "searchbox.html"]}
 html_theme_options = {"logo_only": True}
 
 autosummary_mock_imports = [
-    "peekingduck.pipeline.nodes.dabble.trackingv1",
-    "peekingduck.pipeline.nodes.dabble.utils",
-    "peekingduck.pipeline.nodes.dabble.zoningv1",
-    "peekingduck.pipeline.nodes.draw.utils",
-    "peekingduck.pipeline.nodes.input.utils",
-    "peekingduck.pipeline.nodes.model.csrnetv1",
-    "peekingduck.pipeline.nodes.model.efficientdet_d04",
-    "peekingduck.pipeline.nodes.model.hrnetv1",
-    "peekingduck.pipeline.nodes.model.jdev1",
-    "peekingduck.pipeline.nodes.model.mtcnnv1",
-    "peekingduck.pipeline.nodes.model.posenetv1",
-    "peekingduck.pipeline.nodes.model.movenetv1",
-    "peekingduck.pipeline.nodes.model.yolov4",
-    "peekingduck.pipeline.nodes.model.yolov4_face",
-    "peekingduck.pipeline.nodes.model.yolov4_license_plate",
-    "peekingduck.pipeline.nodes.model.yoloxv1",
-    "peekingduck.pipeline.nodes.output.utils",
-    "peekingduck.utils",
+    "dabble.trackingv1",
+    "dabble.utils",
+    "dabble.zoningv1",
+    "draw.utils",
+    "input.utils",
+    "model.csrnetv1",
+    "model.efficientdet_d04",
+    "model.hrnetv1",
+    "model.jdev1",
+    "model.mtcnnv1",
+    "model.posenetv1",
+    "model.movenetv1",
+    "model.yolov4",
+    "model.yolov4_face",
+    "model.yolov4_license_plate",
+    "model.yoloxv1",
+    "output.utils",
 ]

--- a/docs/source/getting_started/03_custom_nodes.md
+++ b/docs/source/getting_started/03_custom_nodes.md
@@ -2,7 +2,7 @@
 
 You may need to create your own custom nodes. Perhaps you'd like to take a snapshot of a video frame, and post it to your API endpoint; perhaps you have a model trained on a custom dataset, and would like to use PeekingDuck's input, draw, and output nodes. We've designed PeekingDuck to be very flexible --- you can create your own nodes and use them with ours. This guide will showcase how anyone can develop custom nodes to be used with PeekingDuck.
 
-In this guide, we'll be building a custom `csv_writer` node which writes data into a file. It serves as a data collection step that stores useful metrics into a CSV file. This CSV file can be used for logging purposes and can serve as a base for data analytics. (PeekingDuck already has an [`output.csv_writer`](/peekingduck.pipeline.nodes.output.csv_writer) node, but this is a good example for users to experience creating a custom node from scratch.)
+In this guide, we'll be building a custom `csv_writer` node which writes data into a file. It serves as a data collection step that stores useful metrics into a CSV file. This CSV file can be used for logging purposes and can serve as a base for data analytics. (PeekingDuck already has an [`output.csv_writer`](/nodes/output.csv_writer) node, but this is a good example for users to experience creating a custom node from scratch.)
 
 A step by step instruction to build this custom node is provided below.
 

--- a/docs/source/master.rst
+++ b/docs/source/master.rst
@@ -20,14 +20,14 @@ API Documentation
 =================
 
 .. autosummary::
-   :toctree:
+   :toctree: nodes
    :caption: API Documentation
    :template: module.rst
    :recursive:
 
-   peekingduck.pipeline.nodes.input
-   peekingduck.pipeline.nodes.preprocess
-   peekingduck.pipeline.nodes.model
-   peekingduck.pipeline.nodes.dabble
-   peekingduck.pipeline.nodes.draw
-   peekingduck.pipeline.nodes.output
+   input
+   preprocess
+   model
+   dabble
+   draw
+   output

--- a/docs/source/use_cases/crowd_counting.md
+++ b/docs/source/use_cases/crowd_counting.md
@@ -22,7 +22,7 @@ There are two main components to our solution: 1) crowd counting; and 2) heat ma
 
 **1. Crowd Counting**
 
-We use an open source crowd counting model known as [CSRNet](https://arxiv.org/pdf/1802.10062.pdf) to predict the number of people in a sparse or dense crowd. By default, the solution uses the sparse crowd model and this can be changed to the dense crowd model if required. The dense and sparse crowd models were trained using data from ShanghaiTech Part A and ShanghaiTech Part B respectively. As a guideline, you might want to use the dense crowd model if the people in a given image or video frame are packed shoulder to shoulder (e.g. stadiums). For more information on how adjust the CSRNet node, checkout the [CSRNet configurable parameters](/peekingduck.pipeline.nodes.model.csrnet). 
+We use an open source crowd counting model known as [CSRNet](https://arxiv.org/pdf/1802.10062.pdf) to predict the number of people in a sparse or dense crowd. By default, the solution uses the sparse crowd model and this can be changed to the dense crowd model if required. The dense and sparse crowd models were trained using data from ShanghaiTech Part A and ShanghaiTech Part B respectively. As a guideline, you might want to use the dense crowd model if the people in a given image or video frame are packed shoulder to shoulder (e.g. stadiums). For more information on how adjust the CSRNet node, checkout the [CSRNet configurable parameters](/nodes/model.csrnet). 
 
 **2. Heat Map Generation (Optional)**
 
@@ -43,7 +43,7 @@ nodes:
 ```
 
 **1. Crowd Counting Node**
-As mentioned, we use CSRNet to estimate the size of a crowd. As the models were trained to recognise congested scenes, the estimates are less accurate if the number of people are low (e.g. less than 10). In such scenarios, you should consider using an object detection model such as the [YOLOX model](/peekingduck.pipeline.nodes.model.yolox) that is included in our repo.
+As mentioned, we use CSRNet to estimate the size of a crowd. As the models were trained to recognise congested scenes, the estimates are less accurate if the number of people are low (e.g. less than 10). In such scenarios, you should consider using an object detection model such as the [YOLOX model](/nodes/model.yolox) that is included in our repo.
 
 **2. Heat Map Generation Node (Optional)**
 The heat map generation node superimposes a heat map over a given image or video frame.

--- a/docs/source/use_cases/face_mask_detection.md
+++ b/docs/source/use_cases/face_mask_detection.md
@@ -24,7 +24,7 @@ The main component is the detection of face mask using the custom YOLOv4 model.
 
 We use an open source object detection model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of human faces with and without face masks. This allows the application to identify the locations of faces and their corresponding classes (no_mask = 0 or mask = 1) in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected.
 
-The `yolo_face` node detects human faces with and without face masks using the YOLOv4-tiny model by default. The classes are differentiated by the labels and the colours of the bounding boxes when multiple faces are detected. For more information on how adjust the `yolo_face` node, checkout the [`yolo_face` configurable parameters](/peekingduck.pipeline.nodes.model.yolo_face).
+The `yolo_face` node detects human faces with and without face masks using the YOLOv4-tiny model by default. The classes are differentiated by the labels and the colours of the bounding boxes when multiple faces are detected. For more information on how adjust the `yolo_face` node, checkout the [`yolo_face` configurable parameters](/nodes/model.yolo_face).
 
 ## Nodes Used
 
@@ -42,7 +42,7 @@ nodes:
 
 **1. Face Mask Detection Node**
 
-By default, the node uses the YOLOv4-tiny model for face detection. For better accuracy, you can try the [YOLOv4 model](/peekingduck.pipeline.nodes.model.yolo_face) that is included in our repo.
+By default, the node uses the YOLOv4-tiny model for face detection. For better accuracy, you can try the [YOLOv4 model](/nodes/model.yolo_face) that is included in our repo.
 
 **2. Adjusting Nodes**
 

--- a/docs/source/use_cases/human_tracking.md
+++ b/docs/source/use_cases/human_tracking.md
@@ -22,7 +22,7 @@ There are two main components to this MOT: 1) human target detection using AI; a
 
 **1. Human Detection**
 
-We use an open source detection model trained on pedestrian detection and person search datasets known as [JDE](https://arxiv.org/abs/1909.12605) to identify human persons. This allows the application to identify the locations of human persons in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human person detected. For more information on how adjust the JDE node, checkout the [JDE configurable parameters](/peekingduck.pipeline.nodes.model.jde).
+We use an open source detection model trained on pedestrian detection and person search datasets known as [JDE](https://arxiv.org/abs/1909.12605) to identify human persons. This allows the application to identify the locations of human persons in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human person detected. For more information on how adjust the JDE node, checkout the [JDE configurable parameters](/nodes/model.jde).
 
 **2. Appearance Embedding Tracking**
 
@@ -44,7 +44,7 @@ nodes:
 
 **1. JDE Node**
 
-This node employs a single network to *simultaneously* output detection results and the corresponding appearance embeddings of the detected boxes. Therefore JDE stands for Joint Detection and Embedding. More information regarding the model, i.e. research paper and repository can be found [here](https://peekingduck.readthedocs.io/en/stable/peekingduck.pipeline.nodes.model.jde.Node.html).
+This node employs a single network to *simultaneously* output detection results and the corresponding appearance embeddings of the detected boxes. Therefore JDE stands for Joint Detection and Embedding. More information regarding the model, i.e. research paper and repository can be found [here](https://peekingduck.readthedocs.io/en/stable/nodes/model.jde.Node.html).
 
 JDE employs a DarkNet-53 [YOLOv3](https://arxiv.org/abs/1804.02767) as the backbone network for human detection. To learn appearance embeddings, a metric learning algorithm with triplet loss together is used. Observations are assigned to tracklets using the Hungarian algorithm. The Kalman filter is used to smooth the trajectories and predict the locations of previous tracklets in the current frame.
 

--- a/docs/source/use_cases/object_counting.md
+++ b/docs/source/use_cases/object_counting.md
@@ -22,7 +22,7 @@ The main component to obtain the count is the detections from the object detecti
 
 **1. Object Detection**
 
-We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo).
+We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/nodes/model.yolo).
 
 <img src="https://raw.githubusercontent.com/aimakerspace/PeekingDuck/dev/images/readme/yolo_demo.gif" width="70%">
 
@@ -55,7 +55,7 @@ The object counting node is called by including `dabble.bbox_count` in the run c
 
 **3. Adjusting Nodes**
 
-The object counting node does not have changeable configurations. However, it depends on the configuration set in the object detection models, such as the type of object to detect, etc. For object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo) for adjustable behaviours that can influence the result of the object counting node.
+The object counting node does not have changeable configurations. However, it depends on the configuration set in the object detection models, such as the type of object to detect, etc. For object detection model used in this demo, please see the [`yolo` node documentation](/nodes/model.yolo) for adjustable behaviours that can influence the result of the object counting node.
 
 ```{eval-rst}
 For more adjustable node behaviours not listed here, check out the :ref:`API Documentation <api_doc>`.

--- a/docs/source/use_cases/privacy_protection_faces.md
+++ b/docs/source/use_cases/privacy_protection_faces.md
@@ -22,7 +22,7 @@ There are two main components to face anonymisation: 1) face detection using AI;
 
 **1. Face Detection**
 
-We use an open source face detection model known as [MTCNN](https://arxiv.org/abs/1604.02878) to identify human faces. This allows the application to identify the locations of human faces in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected. For more information on how adjust the MTCNN node, checkout the [MTCNN configurable parameters](/peekingduck.pipeline.nodes.model.mtcnn).
+We use an open source face detection model known as [MTCNN](https://arxiv.org/abs/1604.02878) to identify human faces. This allows the application to identify the locations of human faces in a video feed. Each of these locations are represented as a pair of (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each human face detected. For more information on how adjust the MTCNN node, checkout the [MTCNN configurable parameters](/nodes/model.mtcnn).
 
 **2. Face De-Identification**
 

--- a/docs/source/use_cases/privacy_protection_license_plate.md
+++ b/docs/source/use_cases/privacy_protection_license_plate.md
@@ -22,7 +22,7 @@ There are two main components to license plate anonymisation: 1) license plate d
 
 **1. License Plate Detection**
 
-We use open-source object detection models under the [YOLOv4](https://arxiv.org/abs/2004.10934) family to identify the locations of the license plates in an image/video feed. Specifically, we offer the YOLOv4-tiny model, which is faster, and the YOLOv4 model, which provides higher accuracy. The locations of detected license plates are returned as an array of coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each license plate detected. For more information on how to adjust the license plate detector node, check out the [license plate detector configurable parameters](/peekingduck.pipeline.nodes.model.yolo_license_plate).
+We use open-source object detection models under the [YOLOv4](https://arxiv.org/abs/2004.10934) family to identify the locations of the license plates in an image/video feed. Specifically, we offer the YOLOv4-tiny model, which is faster, and the YOLOv4 model, which provides higher accuracy. The locations of detected license plates are returned as an array of coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each license plate detected. For more information on how to adjust the license plate detector node, check out the [license plate detector configurable parameters](/nodes/model.yolo_license_plate).
 
 **2. License Plate De-Identification**
 

--- a/docs/source/use_cases/zone_counting.md
+++ b/docs/source/use_cases/zone_counting.md
@@ -25,7 +25,7 @@ There are three main components to obtain the zone counts:
 
 **1. Object Detection**
 
-We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/peekingduck.pipeline.nodes.model.yolo).
+We use an open source object detection estimation model known as [YOLOv4](https://arxiv.org/abs/2004.10934) and its smaller and faster variant known as YOLOv4-tiny to identify the bounding boxes of chosen objects we want to detect. This allows the application to identify where objects are located within the video feed. The location is returned as two (x, y) coordinates in the form [x1, y1, x2, y2], where (x1, y1) is the top-left corner of the bounding box, and (x2, y2) is the bottom-right. These are used to form the bounding box of each object detected. For more information in how adjust the `yolo` node, checkout the [`yolo` configurable parameters](/nodes/model.yolo).
 
 <img src="https://raw.githubusercontent.com/aimakerspace/PeekingDuck/dev/images/readme/yolo_demo.gif" width="70%">
 
@@ -95,7 +95,7 @@ The zone counting node is called by including `dabble.zone_count` in the run con
 
 **4. Adjusting Nodes**
 
-The zone counting detections depend on the configuration set in the object detection models, such as the type of object to detect, etc. For the object detection model used in this demo, please see the [`yolo` node documentation](/peekingduck.pipeline.nodes.model.yolo) for adjustable behaviours that can influence the result of the zone counting node.
+The zone counting detections depend on the configuration set in the object detection models, such as the type of object to detect, etc. For the object detection model used in this demo, please see the [`yolo` node documentation](/nodes/model.yolo) for adjustable behaviours that can influence the result of the zone counting node.
 
 With regards to the zone counting node, some common node behaviours for the zone counting node that you might need to adjust are:
 - `resolution`: If you are planning to use fractions to set the coordinates for the area of the zone, the resolution should be set to the image/video/livestream resolution used.


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck/issues/576

- add peekingduck.pipeline.nodes to sys.path -> to omit the module prefix from the sidebar

- generate nodes docs in docs/source/nodes -> mostly for convenience in `make clean` target and gitignore

- add docs/source/nodes to "make clean" targer and gitignore

- omit module name in class signature for clarity

NOTE: while there is a way to modify the topbar (breadcrumbs), modifying it only for the API documentation pages does not seem straightforward and is not implemented https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html?highlight=breadcrumb#remove-links-from-top-right-corner