### PR TITLE
Docs: add explanation in node config template

### DIFF
--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
-          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -3,6 +3,9 @@
 Glossary
 ========
 
+The following are built-in data types recognized by PeekingDuck nodes. Users can define custom data
+types when working with custom nodes.
+
 (input) ``all`` (:obj:`Any`): Receives inputs from all preceding outputs. In :mod:`draw.legend`,
 this is used as dynamic input for legend creation. In :mod:`output.csv_writer`, this is used as
 flexible input for statistics to track.

--- a/peekingduck/configs/node_template.yml
+++ b/peekingduck/configs/node_template.yml
@@ -1,12 +1,12 @@
 # Mandatory configs
+# Receive bounding boxes and their respective labels as input. Replace with
+# other data types as required. List of built-in data types for PeekingDuck can
+# be found at https://peekingduck.readthedocs.io/en/stable/glossary.html.
+input: ["bboxes", "bbox_labels"]
 # Example:
-# Use 'input: ["bboxes", "bbox_labels"]' to receive bounding boxes and their
-# respective labels as input
-input: ["in1", "in2"]
-# Example:
-# Use 'output: ["obj_tags", "custom_key"]' to output `obj_tags` visualization
-# with `draw.tag` node and `custom_key` for use with other custom nodes.
-output: ["out1", "out2", "out3"]
+# Output `obj_tags` for visualization with `draw.tag` node and `custom_key` for
+# use with other custom nodes. Replace as required.
+output: ["obj_tags", "custom_key"]
 
 # Optional configs depending on node
 threshold: 0.5 # example

--- a/peekingduck/configs/node_template.yml
+++ b/peekingduck/configs/node_template.yml
@@ -1,7 +1,12 @@
 # Mandatory configs
-input: ["in1", "in2"]             # replace values
-output: ["out1", "out2", "out3"]  # replace values
+# Example:
+# Use 'input: ["bboxes", "bbox_labels"]' to receive bounding boxes and their
+# respective labels as input
+input: ["in1", "in2"]
+# Example:
+# Use 'output: ["obj_tags", "custom_key"]' to output `obj_tags` visualization
+# with `draw.tag` node and `custom_key` for use with other custom nodes.
+output: ["out1", "out2", "out3"]
 
 # Optional configs depending on node
-threshold: 0.5                    # example
-
+threshold: 0.5 # example


### PR DESCRIPTION
- Add more verbose explanation on the values to use for `input` and `output` in `node_template.yml`
- Explicitly mention that users can create custom data types for use with custom nodes in Glossary.
- Disabled `pip` cache in pre-merge CI