### PR TITLE
cicd: enable pip cache in pre merge CI

### DIFF
--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/50

`setup-python` action [has been updated](https://github.com/actions/setup-python/issues/328#issuecomment-1030025436) to fix the cache issue on Windows.

