### PR TITLE
Fix: update CLI nodes URL

### DIFF
--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -375,9 +375,9 @@ def _get_node_url(node_type: str, node_name: str) -> str:
     Returns:
         (str): Full URL to the documentation of the specified node.
     """
-    node_path = f"peekingduck.pipeline.nodes.{node_type}.{node_name}.Node"
-    url_prefix = "https://peekingduck.readthedocs.io/en/stable/"
-    url_postfix = ".html#"
+    node_path = f"{node_type}.{node_name}"
+    url_prefix = "https://peekingduck.readthedocs.io/en/stable/nodes/"
+    url_postfix = ".html#module-"
 
     return f"{url_prefix}{node_path}{url_postfix}{node_path}"
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -68,15 +68,15 @@ def available_nodes_msg(type_name=None):
     else:
         node_types = [type_name]
 
-    url_prefix = "https://peekingduck.readthedocs.io/en/stable/"
-    url_postfix = ".html#"
+    url_prefix = "https://peekingduck.readthedocs.io/en/stable/nodes/"
+    url_postfix = ".html#module-"
     for node_type in node_types:
         node_names = [path.stem for path in (PKD_CONFIG_DIR / node_type).glob("*.yml")]
         max_length = len_enumerate(max(enumerate(node_names), key=len_enumerate))
         print(f"\nPeekingDuck has the following {node_type} nodes:", file=output)
         for num, node_name in enumerate(node_names):
             idx = num + 1
-            node_path = f"peekingduck.pipeline.nodes.{node_type}.{node_name}.Node"
+            node_path = f"{node_type}.{node_name}"
             url = f"{url_prefix}{node_path}{url_postfix}{node_path}"
             node_width = max_length + 1 - int(math.log10(idx))
             print(f"{idx}:{node_name: <{node_width}}Info: {url}", file=output)


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/49

Update the URLs printed by CLI command `nodes` based on latest documentation changes.