### PR TITLE
Docs: use sphinx glossary for PeekingDuck data types

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,16 +4,15 @@ FAQ and Troubleshooting
 How can I post-process and visualize model outputs?
 ---------------------------------------------------
 
-The common output of all ``model`` nodes is ``bboxes``. ``bboxes`` can be used for
-subsequent actions like counting (:mod:`dabble.bbox_count`), drawing (:mod:`draw.bbox`),
-tagging (:mod:`draw.tag`), etc.
-You can also create custom nodes which takes ``boxes`` as an input to visualize your
-results.
+The common output of all ``model`` nodes is :term:`bboxes`. :term:`bboxes` can
+be used for subsequent actions like counting (:mod:`dabble.bbox_count`), drawing
+(:mod:`draw.bbox`), tagging (:mod:`draw.tag`), etc. You can also create custom
+nodes which takes :term:`bboxes` as an input to visualize your results.
 
 How can I dynamically use all prior outputs as the input at run time?
 ---------------------------------------------------------------------
 
-Specifying ``all`` as the input allows the node to receive all prior outputs as the input.
+Specifying ":term:`all <(input) all>`" as the input allows the node to receive all prior outputs as the input.
 This is used by nodes such as :mod:`draw.legend` and :mod:`output.csv_writer`.
 
 How do I debug custom nodes?

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -84,13 +84,14 @@ types when working with custom nodes.
    |zone_count|
       |zone_count_def|
 
-.. deprecated:: 1.2.0 |br|
+.. deprecated:: 1.2.0
     ``obj_tags`` (:obj:`List[str]`) is deprecated and now subsumed under
     :term:`obj_attrs`. :mod:`dabble.check_nearby_objs` now accesses this
     attribute by the ``flags`` key of :term:`obj_attrs`. :mod:`draw.tag` has
     been refactored for more drawing flexibility by accepting :term:`obj_attrs`
     as input. |br|
 
+.. deprecated:: 1.2.0
     ``obj_groups`` (:obj:`List[int]`) is deprecated and now subsumed under 
     :term:`obj_attrs`. Affected nodes (:mod:`dabble.group_nearby_objs`, 
     :mod:`dabble.check_large_groups`, and :mod:`draw.group_bbox_and_tag`) now

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -7,63 +7,92 @@ Glossary
 The following are built-in data types recognized by PeekingDuck nodes. Users can define custom data
 types when working with custom nodes.
 
-(input) |all_input|
+.. glossary::
 
-|bboxes|
+   (input) |all|
+      |all_input_def|
+   
+   |bboxes|
+      |bboxes_def|
 
-|bbox_labels|
+   |bbox_labels|
+      |bbox_labels_def|
 
-|bbox_scores|
-
-|btm_midpoint|
-
-|count|
-
-|cum_avg|
-
-|cum_max|
-
-|cum_min|
-
-|density_map|
-
-|filename|
-
-|fps|
-
-|img|
-
-|keypoints|
-
-|keypoint_conns|
-
-|keypoint_scores|
-
-|large_groups|
-
-(input) |no_input|
-
-(output) |no_output|
-
-|obj_3D_locs|
-
-|obj_attrs|
-
-|pipeline_end|
-
-|saved_video_fps|
-
-|zones|
-
-|zone_count|
+   |bbox_scores|
+      |bbox_scores_def|
+   
+   |btm_midpoint|
+      |btm_midpoint_def|
+   
+   |count|
+      |count_def|
+   
+   |cum_avg|
+      |cum_avg_def|
+   
+   |cum_max|
+      |cum_max_def|
+   
+   |cum_min|
+      |cum_min_def|
+   
+   |density_map|
+      |density_map_def|
+   
+   |filename|
+      |filename_def|
+   
+   |fps|
+      |fps_def|
+   
+   |img|
+      |img_def|
+   
+   |keypoints|
+      |keypoints_def|
+   
+   |keypoint_conns|
+      |keypoint_conns_def|
+   
+   |keypoint_scores|
+      |keypoint_scores_def|
+   
+   |large_groups|
+      |large_groups_def|
+   
+   (input) |none|
+      |none_input_def|
+   
+   (output) |none|
+      |none_output_def|
+   
+   |obj_3D_locs|
+      |obj_3D_locs_def|
+   
+   |obj_attrs|
+      |obj_attrs_def|
+   
+   |pipeline_end|
+      |pipeline_end_def|
+   
+   |saved_video_fps|
+      |saved_video_fps_def|
+   
+   |zones|
+      |zones_def|
+   
+   |zone_count|
+      |zone_count_def|
 
 .. deprecated:: 1.2.0 |br|
+
     ``obj_tags`` (:obj:`List[str]`) is deprecated and now subsumed under
-    ``obj_attrs`` (:obj:`Dict[str, Any]`). :mod:`dabble.check_nearby_objs` now accesses
-    this attribute by the ``flags`` key of ``obj_attrs``. :mod:`draw.tag` has been refactored
-    for more drawing flexibility by accepting ``obj_attrs`` as input. |br|
+    :term:`obj_attrs`. :mod:`dabble.check_nearby_objs` now accesses this
+    attribute by the ``flags`` key of :term:`obj_attrs`. :mod:`draw.tag` has
+    been refactored for more drawing flexibility by accepting :term:`obj_attrs`
+    as input. |br|
 
     ``obj_groups`` (:obj:`List[int]`) is deprecated and now subsumed under 
-    ``obj_attrs`` (:obj:`Dict[str, Any]`). Affected nodes (:mod:`dabble.group_nearby_objs`, 
-    :mod:`dabble.check_large_groups`, :mod:`draw.group_bbox_and_tag`) now access this attribute 
-    by the ``groups`` key of ``obj_attrs``.
+    :term:`obj_attrs`. Affected nodes (:mod:`dabble.group_nearby_objs`, 
+    :mod:`dabble.check_large_groups`, and :mod:`draw.group_bbox_and_tag`) now
+    access this attribute by the ``groups`` key of :term:`obj_attrs`.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -85,7 +85,6 @@ types when working with custom nodes.
       |zone_count_def|
 
 .. deprecated:: 1.2.0 |br|
-
     ``obj_tags`` (:obj:`List[str]`) is deprecated and now subsumed under
     :term:`obj_attrs`. :mod:`dabble.check_nearby_objs` now accesses this
     attribute by the ``flags`` key of :term:`obj_attrs`. :mod:`draw.tag` has

--- a/docs/source/include/data_type.rst
+++ b/docs/source/include/data_type.rst
@@ -40,6 +40,8 @@
 
 .. |none_input_data| replace:: |none|: |none_input_def|
 
+.. |none_output_data| replace:: |none|: |none_output_def|
+
 .. |obj_3D_locs_data| replace:: |obj_3D_locs|: |obj_3D_locs_def|
 
 .. |obj_attrs_data| replace:: |obj_attrs|: |obj_attrs_def|

--- a/docs/source/include/data_type.rst
+++ b/docs/source/include/data_type.rst
@@ -1,88 +1,196 @@
 ..
    Data type substitutions
 
-.. |all_input| replace:: ``all`` (:obj:`Any`): This data type contains all the outputs from
-   preceding nodes, granting a large degree of flexibility to nodes that receive it. Examples of
-   such nodes include :mod:`draw.legend`, :mod:`dabble.statistics`, and :mod:`output.csv_writer`.
+..
+   Docstring config substitutions
 
-.. |bboxes| replace:: ``bboxes`` (:obj:`numpy.ndarray`): A NumPy array of shape :math:`(N, 4)`
-   containing normalized bounding box coordinates of detected objects where :math:`N` is the number
-   of detected objects. Each bounding box is represented as :math:`(x_1, y_1, x_2, y_2)` where
-   :math:`(x_1, y_1)` is the top left corner and :math:`(x_2, y_2)` is the bottom right corner.
+.. |all_input_data| replace:: |all|: |all_input_def|
 
-.. |bbox_labels| replace:: ``bbox_labels`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(N)` containing strings representing the labels of detected objects. The order
-   corresponds to ``bboxes`` and ``bbox_scores``.
+.. |bboxes_data| replace:: |bboxes|: |bboxes_def|
 
-.. |bbox_scores| replace:: ``bbox_scores`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(N)` containing confidence scores :math:`[0, 1]` of detected objects. The order
-   corresponds to ``bboxes`` and ``bbox_labels``.
+.. |bbox_labels_data| replace:: |bbox_labels|: |bbox_labels_def|
 
-.. |btm_midpoint| replace:: ``btm_midpoint`` (:obj:`List[Tuple[int, int]]`): A list of tuples
-   each representing the :math:`(x, y)` coordinate of the bottom middle of a bounding box for use
-   in zone analytics. The order of corresponds to ``bboxes``.
+.. |bbox_scores_data| replace:: |bbox_scores|: |bbox_scores_def|
 
-.. |count| replace:: ``count`` (:obj:`int`): An integer representing the number of counted objects.
+.. |btm_midpoint_data| replace:: |btm_midpoint|: |btm_midpoint_def|
 
-.. |cum_avg| replace:: ``cum_avg`` (:obj:`float`): Cumulative average of an attribute over time.
+.. |count_data| replace:: |count|: |count_def|
 
-.. |cum_max| replace:: ``cum_max`` (:obj:`float | int`): Cumulative maximum of an attribute over time.
+.. |cum_avg_data| replace:: |cum_avg|: |cum_avg_def|
 
-.. |cum_min| replace:: ``cum_min`` (:obj:`float | int`): Cumulative minimum of an attribute over time.
+.. |cum_max_data| replace:: |cum_max|: |cum_max_def|
 
-.. |density_map| replace:: ``density_map`` (:obj:`numpy.ndarray`): A NumPy array representing the
-   number of persons per pixel. The sum of the array returns the total estimated count of people.
+.. |cum_min_data| replace:: |cum_min|: |cum_min_def|
 
-.. |filename| replace:: ``filename`` (:obj:`str`): The filename of video/image being read.
+.. |density_map_data| replace:: |density_map|: |density_map_def|
 
-.. |fps| replace:: ``fps`` (:obj:`float`): A float representing the Frames Per Second (FPS) when
+.. |filename_data| replace:: |filename|: |filename_def|
+
+.. |fps_data| replace:: |fps|: |fps_def|
+
+.. |img_data| replace:: |img|: |img_def|
+
+.. |keypoints_data| replace:: |keypoints|: |keypoints_def|
+
+.. |keypoint_conns_data| replace:: |keypoint_conns|: |keypoint_conns_def|
+
+.. |keypoint_scores_data| replace:: |keypoint_scores|: |keypoint_scores_def|
+
+.. |large_groups_data| replace:: |large_groups|: |large_groups_def|
+
+.. |none_input_data| replace:: |none|: |none_input_def|
+
+.. |obj_3D_locs_data| replace:: |obj_3D_locs|: |obj_3D_locs_def|
+
+.. |obj_attrs_data| replace:: |obj_attrs|: |obj_attrs_def|
+
+.. |pipeline_end_data| replace:: |pipeline_end|: |pipeline_end_def|
+
+.. |saved_video_fps_data| replace:: |saved_video_fps|: |saved_video_fps_def|
+
+.. |zones_data| replace:: |zones|: |zones_def|
+
+.. |zone_count_data| replace:: |zone_count|: |zone_count_def|
+
+..
+   Glossary term/reference substitutions
+
+.. |all| replace:: ``all`` (:obj:`Any`)
+
+.. |bboxes| replace:: ``bboxes`` (:obj:`numpy.ndarray`)
+
+.. |bbox_labels| replace:: ``bbox_labels`` (:obj:`numpy.ndarray`)
+
+.. |bbox_scores| replace:: ``bbox_scores`` (:obj:`numpy.ndarray`)
+
+.. |btm_midpoint| replace:: ``btm_midpoint`` (:obj:`List[Tuple[int, int]]`)
+   
+.. |count| replace:: ``count`` (:obj:`int`)
+   
+.. |cum_avg| replace:: ``cum_avg`` (:obj:`float`)
+   
+.. |cum_max| replace:: ``cum_max`` (:obj:`float | int`)
+   
+.. |cum_min| replace:: ``cum_min`` (:obj:`float | int`)
+   
+.. |density_map| replace:: ``density_map`` (:obj:`numpy.ndarray`)
+
+.. |filename| replace:: ``filename`` (:obj:`str`)
+   
+.. |fps| replace:: ``fps`` (:obj:`float`)
+   
+.. |img| replace:: ``img`` (:obj:`numpy.ndarray`)
+   
+.. |keypoints| replace:: ``keypoints`` (:obj:`numpy.ndarray`)
+   
+.. |keypoint_conns| replace:: ``keypoint_conns`` (:obj:`numpy.ndarray`)
+   
+.. |keypoint_scores| replace:: ``keypoint_scores`` (:obj:`numpy.ndarray`)
+
+.. |large_groups| replace:: ``large_groups`` (:obj:`List[int]`)
+   
+.. |none| replace:: ``none``
+   
+.. |obj_3D_locs| replace:: ``obj_3D_locs`` (:obj:`List[numpy.ndarray]`)
+   
+.. |obj_attrs| replace:: ``obj_attrs`` (:obj:`Dict[str, Any]`)
+
+.. |pipeline_end| replace:: ``pipeline_end`` (:obj:`bool`)
+   
+.. |saved_video_fps| replace:: ``saved_video_fps`` (:obj:`float`)
+   
+.. |zones| replace:: ``zones`` (:obj:`List[List[Tuple[float, ...]]]`)
+   
+.. |zone_count| replace:: ``zone_count`` (:obj:`List[int]`)
+
+..
+   Glossary definition substitutions
+
+.. |all_input_def| replace:: This data type contains all the outputs from
+   preceding nodes, granting a large degree of flexibility to nodes that receive
+   it. Examples of such nodes include :mod:`draw.legend`,
+   :mod:`dabble.statistics`, and :mod:`output.csv_writer`.
+
+.. |bboxes_def| replace:: A NumPy array of shape :math:`(N, 4)` containing
+   normalized bounding box coordinates of detected objects where :math:`N` is
+   the number of detected objects. Each bounding box is represented as
+   :math:`(x_1, y_1, x_2, y_2)` where :math:`(x_1, y_1)` is the top left corner
+   and :math:`(x_2, y_2)` is the bottom right corner. The order corresponds to
+   :term:`bbox_labels` and :term:`bbox_scores`.
+
+.. |bbox_labels_def| replace:: A NumPy array of shape :math:`(N)` containing
+   strings representing the labels of detected objects. The order corresponds to
+   :term:`bboxes` and :term:`bbox_scores`.
+
+.. |bbox_scores_def| replace:: A NumPy array of shape :math:`(N)` containing
+   confidence scores :math:`[0, 1]` of detected objects. The order corresponds
+   to :term:`bboxes` and :term:`bbox_labels`.
+
+.. |btm_midpoint_def| replace:: A list of tuples each representing the
+   :math:`(x, y)` coordinate of the bottom middle of a bounding box for use in
+   zone analytics. The order of corresponds to :term:`bboxes`.
+
+.. |count_def| replace:: An integer representing the number of counted objects.
+
+.. |cum_avg_def| replace:: Cumulative average of an attribute over time.
+
+.. |cum_max_def| replace:: Cumulative maximum of an attribute over time.
+
+.. |cum_min_def| replace:: Cumulative minimum of an attribute over time.
+
+.. |density_map_def| replace:: A NumPy array representing the number of persons
+   per pixel. The sum of the array returns the total estimated count of people.
+
+.. |filename_def| replace:: The filename of video/image being read.
+
+.. |fps_def| replace:: A float representing the Frames Per Second (FPS) when
    processing a live video stream or a recorded video.
 
-.. |img| replace:: ``img`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(height, width, channels)` containing the image data in BGR format.
+.. |img_def| replace:: A NumPy array of shape :math:`(height, width, channels)`
+   containing the image data in BGR format.
 
-.. |keypoints| replace:: ``keypoints`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(N, K, 2)` containing the `x, y` coordinates of detected poses where :math:`N` is the
-   number of detected poses, and :math:`K` is the number of individual keypoints. Keypoints with
-   low confidence scores (below threshold) will be replaced by ``-1``.
+.. |keypoints_def| replace:: A NumPy array of shape:math:`(N, K, 2)` containing
+   the `x, y` coordinates of detected poses where :math:`N` is the number of
+   detected poses, and :math:`K` is the number of individual keypoints.
+   Keypoints with low confidence scores (below threshold) will be replaced by
+   ``-1``.
 
-.. |keypoint_conns| replace:: ``keypoint_conns`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(N, D', 2)` containing the `x, y` coordinates of adjacent keypoint pairs. :math:`D'` is
+.. |keypoint_conns_def| replace:: A NumPy array of shape :math:`(N, D', 2)`
+   containing the `x, y` coordinates of adjacent keypoint pairs. :math:`D'` is
    the number of valid keypoint pairs where both keypoints are detected.
 
-.. |keypoint_scores| replace:: ``keypoint_scores`` (:obj:`numpy.ndarray`): A NumPy array of shape
-   :math:`(N, K, 1)` containing the confidence scores of detected poses where :math:`N` is the
-   number of detected poses and :math:`K` is the number of individual keypoints. The confidence
-   score has a range of :math:`[0, 1]`.
+.. |keypoint_scores_def| replace:: A NumPy array of shape :math:`(N, K, 1)`
+   containing the confidence scores of detected poses where :math:`N` is the
+   number of detected poses and :math:`K` is the number of individual keypoints.
+   The confidence score has a range of :math:`[0, 1]`.
 
-.. |large_groups| replace:: ``large_groups`` (:obj:`List[int]`): A list of integers representing
-   the group IDs of groups that have exceeded the size threshold.
+.. |large_groups_def| replace:: A list of integers representing the group IDs of
+   groups that have exceeded the size threshold.
 
-.. |no_input| replace:: ``none``: No inputs required.
+.. |none_input_def| replace:: No inputs required.
 
-.. |no_output| replace:: ``none``: No outputs produced.
+.. |none_output_def| replace:: No outputs produced.
 
-.. |obj_3D_locs| replace:: ``obj_3D_locs`` (:obj:`List[numpy.ndarray]`): A list of :math:`N` NumPy
-   arrays representing the 3D coordinates :math:`(x, y, z)` of an object associated with a detected
+.. |obj_3D_locs_def| replace:: A list of :math:`N` NumPy arrays representing the
+   3D coordinates :math:`(x, y, z)` of an object associated with a detected
    bounding box.
 
-.. |obj_attrs| replace:: ``obj_attrs`` (:obj:`Dict[str, Any]`): A dictionary of attributes
-   associated with each bounding box, in the same order as ``bboxes``. Different nodes that 
-   produce this ``obj_attrs`` output type may contribute different attributes. For example, 
-   ``dabble.tracking`` produces the ``ids`` attribute while ``dabble.check_nearby_objs`` produces 
-   the ``flags`` attribute.
+.. |obj_attrs_def| replace:: A dictionary of attributes associated with each
+   bounding box, in the same order as :term:`bboxes`. Different nodes that
+   produce this :term:`obj_attrs` output type may contribute different attributes.
+   For example, :mod:`dabble.tracking` produces the ``ids`` attribute while
+   :mod:`dabble.check_nearby_objs` produces the ``flags`` attribute.
 
-.. |pipeline_end| replace:: ``pipeline_end`` (:obj:`bool`): A boolean that evaluates to ``True``
-   when the pipeline is completed. Suitable for operations that require the entire inference
-   pipeline to be completed before running.
+.. |pipeline_end_def| replace:: A boolean that evaluates to ``True`` when the
+   pipeline is completed. Suitable for operations that require the entire
+   inference pipeline to be completed before running.
 
-.. |saved_video_fps| replace:: ``saved_video_fps`` (:obj:`float`): FPS of the recorded video, upon
-   filming.
+.. |saved_video_fps_def| replace:: FPS of the recorded video, upon filming.
 
-.. |zones| replace:: ``zones`` (:obj:`List[List[Tuple[float, ...]]]`): A nested list of
-   coordinates, with each sub-list containing the :math:`(x, y)` coordinates representing the points that
-   form the boundaries of a zone. The order corresponds to ``zone_count``.
+.. |zones_def| replace:: A nested list of coordinates, with each sub-list
+   containing the :math:`(x, y)` coordinates representing the points that form
+   the boundaries of a zone. The order corresponds to :term:`zone_count`.
 
-.. |zone_count| replace:: ``zone_count`` (:obj:`List[int]`): A list of integers representing the
-   count of a pre-selected object class (for example, "person") detected in each specified zone.
-   The order corresponds to ``zones``.
+.. |zone_count_def| replace:: A list of integers representing the count of a
+   pre-selected object class (for example, "person") detected in each specified
+   zone. The order corresponds to :term:`zones`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,7 +64,7 @@ PeekingDuck has 6 types of nodes:
 
 A **pipeline** governs the behavior of a chain of nodes. The diagram below shows the pipeline used
 in the previous demo. Nodes in a pipeline are called in sequential order, and the output of one
-node will be the input to another. For example, :mod:`input.live` produces ``img``, which is taken
+node will be the input to another. For example, :mod:`input.live` produces :term:`img`, which is taken
 in by :mod:`model.yolo`, and :mod:`model.yolo` produces ``bboxes``, which is taken in by
 :mod:`draw.bbox`. For ease of visualization, not all the inputs and outputs of these nodes are
 included in this diagram.

--- a/docs/source/tutorials/03_custom_nodes.rst
+++ b/docs/source/tutorials/03_custom_nodes.rst
@@ -129,11 +129,11 @@ implement our custom node function.
 
    To display the bounding box confidence score, our node requires three pieces
    of input data: the bounding box, the score to display, and the image to draw on.
-   These are defined as ``bboxes``, ``bbox_scores``, and ``img`` respectively in the 
+   These are defined as :term:`bboxes`, :term:`bbox_scores`, and :term:`img` respectively in the 
    :ref:`API docs <api_doc>`.
 
    Our custom node only displays the score on screen and does not produce any
-   outputs for the pipeline, so the output is ``none``.
+   outputs for the pipeline, so the output is ":term:`none <(output) none>`".
 
    There are also no optional configs, so lines 11 - 12 can be removed.
 
@@ -388,7 +388,7 @@ To implement this tutorial, the **three files** ``wave.yml``, ``wave.py`` and
       # No optional configs
 
 We will implement this tutorial using a ``dabble`` node, which will take the 
-inputs ``img``, ``bboxes``, ``bbox_scores``, ``keypoints``, and ``keypoint_scores`` 
+inputs :term:`img`, :term:`bboxes`, :term:`bbox_scores`, :term:`keypoints`, and :term:`keypoint_scores` 
 from the pipeline. The node has no output.
 
 2. **src/custom_nodes/dabble/wave.py**:
@@ -691,7 +691,8 @@ The updated folder structure is:
 
 Then, make the following **three** changes:
 
-1. Specify ``debug.yml`` to receive everything ``all`` from the pipeline, as follows:
+1. Specify ``debug.yml`` to receive everything ":term:`all <(input) all>`" from
+   the pipeline, as follows:
 
    .. code-block:: yaml
       :linenos:
@@ -760,7 +761,7 @@ Then, make the following **three** changes:
 
    The custom node code shows how to see what is available in PeekingDuck's pipeline 
    data pool by printing the input dictionary keys.
-   It also demonstrates how to debug a specific data object, such as ``bboxes``, by
+   It also demonstrates how to debug a specific data object, such as :term:`bboxes`, by
    printing relevant information for each item within the data.
 
 3. Update **pipeline_config.yml**:

--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -490,7 +490,7 @@ output a list of bboxes within the zone, dropping all bboxes outside it.
 Then, ``dabble.tracking`` is used to track the people walking and 
 ``dabble.statistics`` is used to determine the number of people walking in the zone,
 by getting the maximum of the tracked IDs.
-``draw.legend`` has a new item ``zone_count`` which displays the number of people 
+``draw.legend`` has a new item :term:`zone_count` which displays the number of people 
 walking in the zone currently.
 
 The ``filter_bbox.yml`` and ``filter_bbox.py`` files are shown below:

--- a/peekingduck/pipeline/nodes/augment/brightness.py
+++ b/peekingduck/pipeline/nodes/augment/brightness.py
@@ -31,10 +31,10 @@ class Node(AbstractNode):
     linear_transform.html>`_.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         beta (:obj:`int`): **[-100,100], default = 0**. |br|

--- a/peekingduck/pipeline/nodes/augment/contrast.py
+++ b/peekingduck/pipeline/nodes/augment/contrast.py
@@ -30,10 +30,10 @@ class Node(AbstractNode):
     linear_transform.html>`_.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         alpha (:obj:`float`): **[0, 3], default = 1**. |br|

--- a/peekingduck/pipeline/nodes/dabble/bbox_count.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_count.py
@@ -25,10 +25,10 @@ class Node(AbstractNode):
     """Counts total number of detected objects.
 
     Inputs:
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |count|
+        |count_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
@@ -27,10 +27,10 @@ class Node(AbstractNode):
     """Uses 2D bounding boxes information to estimate 3D location.
 
     Inputs:
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |obj_3D_locs|
+        |obj_3D_locs_data|
 
     Configs:
         focal_length (:obj:`float`): **default = 1.14**. |br|

--- a/peekingduck/pipeline/nodes/dabble/bbox_to_btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_to_btm_midpoint.py
@@ -31,12 +31,12 @@ class Node(AbstractNode):
     located.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |btm_midpoint|
+        |btm_midpoint_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/dabble/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/dabble/check_large_groups.py
@@ -23,9 +23,9 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 
 
 class Node(AbstractNode):
-    """
-    Checks which groups have exceeded the group size threshold. The group associated with each
-    object is accessed by the ``groups`` key of ``obj_attrs``.
+    """Checks which groups have exceeded the group size threshold. The group
+    associated with each object is accessed by the ``groups`` key of
+    :term:`obj_attrs`.
 
     Inputs:
         |obj_attrs_data|
@@ -38,10 +38,10 @@ class Node(AbstractNode):
             Threshold of group size.
 
     .. versionchanged:: 1.2.0 |br|
-        :mod:`draw.check_large_groups` used to take in ``obj_tags`` (:obj:`List[str]`) as an input
-        data type, which has been deprecated and now subsumed under ``obj_attrs``
-        (:obj:`Dict[str, Any]`). The same attribute is accessed by the ``groups`` key of
-        ``obj_attrs``.
+        :mod:`draw.check_large_groups` used to take in ``obj_tags``
+        (:obj:`List[str]`) as an input data type, which has been deprecated and
+        now subsumed under :term:`obj_attrs`. The same attribute is accessed by
+        the ``groups`` key of :term:`obj_attrs`.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/dabble/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/dabble/check_large_groups.py
@@ -37,7 +37,7 @@ class Node(AbstractNode):
         group_size_threshold (:obj:`int`): **default = 5**. |br|
             Threshold of group size.
 
-    .. versionchanged:: 1.2.0 |br|
+    .. versionchanged:: 1.2.0
         :mod:`draw.check_large_groups` used to take in ``obj_tags``
         (:obj:`List[str]`) as an input data type, which has been deprecated and
         now subsumed under :term:`obj_attrs`. The same attribute is accessed by

--- a/peekingduck/pipeline/nodes/dabble/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/dabble/check_large_groups.py
@@ -28,10 +28,10 @@ class Node(AbstractNode):
     object is accessed by the ``groups`` key of ``obj_attrs``.
 
     Inputs:
-        |obj_attrs|
+        |obj_attrs_data|
 
     Outputs:
-        |large_groups|
+        |large_groups_data|
 
     Configs:
         group_size_threshold (:obj:`int`): **default = 5**. |br|

--- a/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
@@ -44,7 +44,7 @@ class Node(AbstractNode):
         tag_msg (:obj:`str`): **default = "TOO CLOSE!"**. |br|
             Tag to identify objects which are near others.
 
-    .. versionchanged:: 1.2.0 |br|
+    .. versionchanged:: 1.2.0
         :mod:`draw.check_nearby_objs` used to return ``obj_tags``
         (:obj:`List[str]`) as an output data type, which has been deprecated
         and now subsumed under :term:`obj_attrs`. The same attribute is

--- a/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
@@ -31,10 +31,10 @@ class Node(AbstractNode):
     as near with ``tag_msg``. These flags can be accessed by the ``flags`` key of ``obj_attrs``.
 
     Inputs:
-        |obj_3D_locs|
+        |obj_3D_locs_data|
 
     Outputs:
-        |obj_attrs|
+        |obj_attrs_data|
 
     Configs:
         near_threshold (:obj:`float`): **default = 2.0**. |br|

--- a/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
@@ -26,9 +26,10 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Checks if any objects are near each other.
 
-    It does so by comparing the 3D locations of all objects to see which ones are near each other.
-    If the distance between two objects is less than the minimum threshold, both would be flagged
-    as near with ``tag_msg``. These flags can be accessed by the ``flags`` key of ``obj_attrs``.
+    It does so by comparing the 3D locations of all objects to see which ones
+    are near each other. If the distance between two objects is below the
+    minimum threshold, both would be flagged as near with ``tag_msg``. These
+    flags can be accessed by the ``flags`` key of :term:`obj_attrs`.
 
     Inputs:
         |obj_3D_locs_data|
@@ -38,16 +39,16 @@ class Node(AbstractNode):
 
     Configs:
         near_threshold (:obj:`float`): **default = 2.0**. |br|
-            Threshold of distance, in metres, between two objects. Objects with distance less than
-            ``near_threshold`` would be considered as 'near'.
+            Threshold of distance, in metres, between two objects. Objects with
+            distance less than ``near_threshold`` would be considered as 'near'.
         tag_msg (:obj:`str`): **default = "TOO CLOSE!"**. |br|
             Tag to identify objects which are near others.
 
     .. versionchanged:: 1.2.0 |br|
-        :mod:`draw.check_nearby_objs` used to return ``obj_tags`` (:obj:`List[str]`) as an output
-        data type, which has been deprecated and now subsumed under ``obj_attrs``
-        (:obj:`Dict[str, Any]`). The same attribute is accessed by the ``flags`` key of
-        ``obj_attrs``.
+        :mod:`draw.check_nearby_objs` used to return ``obj_tags``
+        (:obj:`List[str]`) as an output data type, which has been deprecated
+        and now subsumed under :term:`obj_attrs`. The same attribute is
+        accessed by the ``flags`` key of :term:`obj_attrs`.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/dabble/fps.py
+++ b/peekingduck/pipeline/nodes/dabble/fps.py
@@ -32,10 +32,10 @@ class Node(AbstractNode):
     FPS. A preferred output setting can be set via the configuration file.
 
     Inputs:
-        |pipeline_end|
+        |pipeline_end_data|
 
     Outputs:
-        |fps|
+        |fps_data|
 
     Configs:
         fps_log_display (:obj:`bool`): **default = False**. |br|

--- a/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
@@ -27,9 +27,9 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Groups objects that are near each other.
 
-    It does so by comparing the 3D locations of all objects, and assigning objects near each other
-    to the same group. The group associated with each object is accessed by the ``groups`` key of
-    ``obj_attrs``.
+    It does so by comparing the 3D locations of all objects, and assigning
+    objects near each other to the same group. The group associated with each
+    object is accessed by the ``groups`` key of :term:`obj_attrs`.
 
     Inputs:
         |obj_3D_locs_data|
@@ -40,14 +40,14 @@ class Node(AbstractNode):
     Configs:
         obj_dist_threshold (:obj:`float`): **default = 1.5**. |br|
             Threshold of distance, in metres, between two objects. Objects with
-            distance less than ``obj_dist_threshold`` would be assigned to the same
-            group.
+            distance less than ``obj_dist_threshold`` would be assigned to the
+            same group.
 
     .. versionchanged:: 1.2.0 |br|
-        :mod:`draw.group_nearby_objs` used to return ``obj_tags`` (:obj:`List[str]`) as an output
-        data type, which has been deprecated and now subsumed under ``obj_attrs``
-        (:obj:`Dict[str, Any]`). The same attribute is accessed by the ``groups`` key of
-        ``obj_attrs``.
+        :mod:`draw.group_nearby_objs` used to return ``obj_tags``
+        (:obj:`List[str]`) as an output data type, which has been deprecated
+        and now subsumed under :term:`obj_attrs`. The same attribute is
+        accessed by the ``groups`` key of :term:`obj_attrs`.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
@@ -32,10 +32,10 @@ class Node(AbstractNode):
     ``obj_attrs``.
 
     Inputs:
-        |obj_3D_locs|
+        |obj_3D_locs_data|
 
     Outputs:
-        |obj_attrs|
+        |obj_attrs_data|
 
     Configs:
         obj_dist_threshold (:obj:`float`): **default = 1.5**. |br|

--- a/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
@@ -43,7 +43,7 @@ class Node(AbstractNode):
             distance less than ``obj_dist_threshold`` would be assigned to the
             same group.
 
-    .. versionchanged:: 1.2.0 |br|
+    .. versionchanged:: 1.2.0
         :mod:`draw.group_nearby_objs` used to return ``obj_tags``
         (:obj:`List[str]`) as an output data type, which has been deprecated
         and now subsumed under :term:`obj_attrs`. The same attribute is

--- a/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
@@ -34,10 +34,10 @@ class Node(AbstractNode):
     """Uses pose keypoint information of torso to estimate 3D location.
 
     Inputs:
-        |keypoints|
+        |keypoints_data|
 
     Outputs:
-        |obj_3D_locs|
+        |obj_3D_locs_data|
 
     Configs:
         focal_length (:obj:`float`): **default = 1.14**. |br|

--- a/peekingduck/pipeline/nodes/dabble/statistics.py
+++ b/peekingduck/pipeline/nodes/dabble/statistics.py
@@ -123,18 +123,18 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
     +---------------------------------------+-------------------+-------------------+-------------+
 
     Inputs:
-        |all_input|
+        |all_input_data|
 
     Outputs:
-        |cum_avg|
+        |cum_avg_data|
 
         Note that ``cum_avg`` will not be updated if there are no detections. For example, if
         ``cum_avg`` = 10 for video frame 1, and there are no detections in the following 500
         frames, ``cum_avg`` is still 10 for video frame 501.
 
-        |cum_max|
+        |cum_max_data|
 
-        |cum_min|
+        |cum_min_data|
 
     Configs:
         identity (:obj:`str`): **default=null** |br|

--- a/peekingduck/pipeline/nodes/dabble/statistics.py
+++ b/peekingduck/pipeline/nodes/dabble/statistics.py
@@ -34,17 +34,20 @@ OPS = {
 
 
 class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
-    """Calculates the cumulative average, minimum and maximum of a single variable of interest
-    (defined as ``current result`` here) over time. The configurations for this node offer several
-    functions to reduce the incoming data type into a single ``current result`` of type :obj:`int`
-    or :obj:`float`, which is valid for the current video frame. ``current result`` is then used to
-    recalculate the values of cumulative average, minimum, and maximum for PeekingDuck's running
-    duration thus far.
+    """Calculates the cumulative average, minimum and maximum of a single
+    variable of interest (defined as ``current result`` here) over time. The
+    configurations for this node offer several functions to reduce the incoming
+    data type into a single ``current result`` of type :obj:`int` or
+    :obj:`float`, which is valid for the current video frame.
+    ``current result`` is then used to recalculate the values of cumulative
+    average, minimum, and maximum for PeekingDuck's running duration thus far.
 
-    The configuration for this node is described below using a combination of the `Extended BNF
-    <https://en.wikipedia.org/wiki/Extended_Backus–Naur_form>`_ and `Augmented BNF
-    <https://en.wikipedia.org/wiki/Augmented_Backus–Naur_form>`_ metasyntax. Concrete examples
-    are provided later for illustration. ::
+    The configuration for this node is described below using a combination of
+    the `Extended BNF
+    <https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form>`_ and
+    `Augmented BNF
+    <https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form>`_
+    metasyntax. Concrete examples are provided later for illustration. ::
 
         pkd_data_type   = ? PeekingDuck built-in data types ?
                           e.g. count, large_groups, obj_attrs
@@ -73,16 +76,16 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
 
     Points to note:
 
-    * Square brackets (``[]``) are used to define ``<dict_key>``, and should not be used
-      elsewhere in the configuration.
+        * Square brackets (``[]``) are used to define ``<dict_key>``, and
+          should not be used elsewhere in the configuration.
+        * Operands are processed differently depending on whether they are
+          enclosed by single/double quotes, or not. If enclosed, the operand is
+          assumed to be of type :obj:`str` and classified as ``<str_operand>``.
+          If not, the operand is classified as ``<num_operand>`` and converted
+          into :obj:`float` for further processing.
 
-    * Operands are processed differently depending on whether they are enclosed by single/double
-      quotes, or not. If enclosed, the operand is assumed to be of type :obj:`str` and classified
-      as ``<str_operand>``. If not, the operand is classified as ``<num_operand>`` and converted
-      into :obj:`float` for further processing.
-
-    The table below illustrates how configuration choices reduce the incoming data type into the
-    ``<current result>``.
+    The table below illustrates how configuration choices reduce the incoming
+    data type into the ``<current result>``.
 
     +---------------------------------------+-------------------+-------------------+-------------+
     | ``<pkd_data_type>``: value            | ``<target_attr>`` | ``<unary_expr>``  | ``<current  |
@@ -128,9 +131,10 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
     Outputs:
         |cum_avg_data|
 
-        Note that ``cum_avg`` will not be updated if there are no detections. For example, if
-        ``cum_avg`` = 10 for video frame 1, and there are no detections in the following 500
-        frames, ``cum_avg`` is still 10 for video frame 501.
+        Note that :term:`cum_avg` will not be updated if there are no
+        detections. For example, if :term:`cum_avg` = 10 for video frame 1, and
+        there are no detections in the following 500 frames, :term:`cum_avg` is
+        still 10 for video frame 501.
 
         |cum_max_data|
 
@@ -138,26 +142,29 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
 
     Configs:
         identity (:obj:`str`): **default=null** |br|
-            Accepts ``<target_attr>`` of types :obj:`int` or :obj:`float`, and returns the
-            same value.
+            Accepts ``<target_attr>`` of types :obj:`int` or :obj:`float`, and
+            returns the same value.
         length (:obj:`str`): **default=null** |br|
-            Accepts ``<target_attr>`` of types :obj:`List[Any]` or :obj:`Dict[str, Any]`,
-            and returns its length.
+            Accepts ``<target_attr>`` of types :obj:`List[Any]` or
+            :obj:`Dict[str, Any]`, and returns its length.
         minimum (:obj:`str`): **default=null** |br|
             Accepts ``<target_attr>`` of types :obj:`List[float | int]` or
-            :obj:`Dict[str, float | int]`, and returns the minimum element within for the current
-            frame. Not to be confused with the ``cum_min`` output data type, which represents the
-            cumulative minimum over time.
+            :obj:`Dict[str, float | int]`, and returns the minimum element
+            within for the current frame. Not to be confused with the
+            :term:`cum_min` output data type, which represents the cumulative
+            minimum over time.
         maximum (:obj:`str`): **default=null** |br|
             Accepts ``<target_attr>`` of types :obj:`List[float | int]` or
-            :obj:`Dict[str, float | int]`, and returns the maximum element within for the current
-            frame. Not to be confused with the ``cum_max`` output data type, which represents the
-            cumulative maximum over time.
+            :obj:`Dict[str, float | int]`, and returns the maximum element
+            within for the current frame. Not to be confused with the
+            :term:`cum_max` output data type, which represents the cumulative
+            maximum over time.
         cond_count (:obj:`str`): **default=null** |br|
-            Accepts ``<target_attr>`` of types :obj:`List[float | int | str]`, and checks if each
-            element in the list fulfils the condition described by ``<num_comparison>`` or
-            ``<str_comparison>``. The number of elements that fulfil the condition are counted
-            towards ``<current result>``.
+            Accepts ``<target_attr>`` of types :obj:`List[float | int | str]`,
+            and checks if each element in the list fulfils the condition
+            described by ``<num_comparison>`` or ``<str_comparison>``. The
+            number of elements that fulfil the condition are counted towards
+            ``<current result>``.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/dabble/tracking.py
+++ b/peekingduck/pipeline/nodes/dabble/tracking.py
@@ -26,7 +26,7 @@ class Node(AbstractNode):
     """Uses bounding boxes detected by an object detector model to track
     multiple objects.
 
-    Currently, two types of tracking algorithms can be selected: MOSSE, IOU.
+    Currently, two types of tracking algorithms can be selected: MOSSE and IOU.
     Information on the algorithms' performance can be found
     :ref:`here <object-tracking-benchmarks>`.
 
@@ -43,9 +43,9 @@ class Node(AbstractNode):
             Type of tracking algorithm to be used. For more information about
             the trackers, please view the :doc:`Multiple Object Tracking use
             case </use_cases/multiple_object_tracking>`.
-        iou_threshold (float): **[0, 1], default=0.1**. |br|
+        iou_threshold (:obj:`float`): **[0, 1], default=0.1**. |br|
             Minimum IoU value to be used with the matching logic.
-        max_lost (int): **[0, sys.maxsize), default=10**. |br|
+        max_lost (:obj:`int`): **[0, sys.maxsize), default=10**. |br|
             Maximum number of frames to keep "lost" tracks after which they
             will be removed. Only used when ``tracking_type = iou``.
     """

--- a/peekingduck/pipeline/nodes/dabble/tracking.py
+++ b/peekingduck/pipeline/nodes/dabble/tracking.py
@@ -31,12 +31,12 @@ class Node(AbstractNode):
     :ref:`here <object-tracking-benchmarks>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |obj_attrs|
+        |obj_attrs_data|
 
     Configs:
         tracking_type (:obj:`str`): **{"iou", "mosse"}, default="iou"**. |br|

--- a/peekingduck/pipeline/nodes/dabble/zone_count.py
+++ b/peekingduck/pipeline/nodes/dabble/zone_count.py
@@ -32,12 +32,12 @@ class Node(AbstractNode):
     such as the type of object to detect.
 
     Inputs:
-        |btm_midpoint|
+        |btm_midpoint_data|
 
     Outputs:
-        |zones|
+        |zones_data|
 
-        |zone_count|
+        |zone_count_data|
 
     Configs:
         resolution (:obj:`List[int]`): **default = [1280, 720]**. |br|

--- a/peekingduck/pipeline/nodes/draw/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/__init__.py
@@ -16,6 +16,6 @@
 Draws results/outputs to an image.
 
 .. deprecated:: 1.2.0 |br|
-    :mod:`draw.image_processor` is deprecated, and replaced by the nodes :mod:`augment.brightness`
-    and :mod:`augment.contrast`.
+    :mod:`draw.image_processor` is deprecated, and replaced by the nodes
+    :mod:`augment.brightness` and :mod:`augment.contrast`.
 """

--- a/peekingduck/pipeline/nodes/draw/__init__.py
+++ b/peekingduck/pipeline/nodes/draw/__init__.py
@@ -15,7 +15,7 @@
 """
 Draws results/outputs to an image.
 
-.. deprecated:: 1.2.0 |br|
+.. deprecated:: 1.2.0
     :mod:`draw.image_processor` is deprecated, and replaced by the nodes
     :mod:`augment.brightness` and :mod:`augment.contrast`.
 """

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -31,14 +31,14 @@ class Node(AbstractNode):
     :doc:`Object Counting use case </use_cases/object_counting>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         show_labels (:obj:`bool`): **default = False**. |br|

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -25,8 +25,8 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Draws bounding boxes on image.
 
-    The ``draw.bbox`` node uses the ``bboxes`` and, optionally, the
-    ``bbox_labels`` from the model predictions to draw the bbox predictions
+    The :mod:`draw.bbox` node uses :term:`bboxes` and, optionally,
+    :term:`bbox_labels` from the model predictions to draw the bbox predictions
     onto the image. For better understanding of the use case, refer to the
     :doc:`Object Counting use case </use_cases/object_counting>`.
 
@@ -42,8 +42,8 @@ class Node(AbstractNode):
 
     Configs:
         show_labels (:obj:`bool`): **default = False**. |br|
-            If ``True``, shows class label, e.g. "person", above the bounding
-            box
+            If ``True``, shows class label, e.g., "person", above the bounding
+            box.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/draw/blur_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/blur_bbox.py
@@ -27,8 +27,8 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     """Blurs area bounded by bounding boxes on image.
 
-    The ``blur_bbox`` node blurs the areas of the image bounded by the bounding
-    boxes output from an object detection model.
+    The :mod:`draw.blur_bbox` node blurs the areas of the image bounded by the
+    bounding boxes output from an object detection model.
 
     Inputs:
         |img_data|

--- a/peekingduck/pipeline/nodes/draw/blur_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/blur_bbox.py
@@ -31,12 +31,12 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     boxes output from an object detection model.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         blur_kernel_size (:obj:`int`): **default = 50**. |br|

--- a/peekingduck/pipeline/nodes/draw/btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/draw/btm_midpoint.py
@@ -32,12 +32,12 @@ class Node(AbstractNode):
     </use_cases/zone_counting>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |btm_midpoint|
+        |btm_midpoint_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/draw/btm_midpoint.py
+++ b/peekingduck/pipeline/nodes/draw/btm_midpoint.py
@@ -26,7 +26,7 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Draws the bottom middle point of detected bounding boxes.
 
-    The ``draw.btm_midpoint`` node uses the ``bboxes`` from the model
+    The :mod:`draw.btm_midpoint` node uses :term:`bboxes` from the model
     predictions to draw the bbox predictions onto the image. For better
     understanding of the use case, refer to the :doc:`Zone Counting use case
     </use_cases/zone_counting>`.

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -37,16 +37,16 @@ class Node(AbstractNode):
     the :doc:`Group Size Checking use case </use_cases/group_size_checking>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
-        |obj_attrs|
+        |obj_attrs_data|
 
-        |large_groups|
+        |large_groups_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         tag (:obj:`str`): **default = "LARGE GROUP!"**. |br|

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -26,12 +26,13 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 
 
 class Node(AbstractNode):
-    """Draws large bounding boxes with tags over multiple object bounding boxes which have been
-    identified as belonging to the same group.
+    """Draws large bounding boxes with tags over multiple object bounding boxes
+    which have been identified as belonging to the same group.
 
-    The ``large_groups`` data type from :mod:`dabble.check_large_groups`, and the ``groups`` key
-    of the ``obj_attrs`` data type from :mod:`dabble.group_nearby_objs`, are inputs to this node
-    which identify the different groups, and the group associated with each bounding box.
+    The :term:`large_groups` data type from :mod:`dabble.check_large_groups`,
+    and the ``groups`` key of the :term:`obj_attrs` data type from
+    :mod:`dabble.group_nearby_objs`, are inputs to this node which identify the
+    different groups, and the group associated with each bounding box.
 
     For better understanding, refer to
     the :doc:`Group Size Checking use case </use_cases/group_size_checking>`.
@@ -53,10 +54,10 @@ class Node(AbstractNode):
             The string message printed when a large group is detected.
 
     .. versionchanged:: 1.2.0 |br|
-        :mod:`draw.group_bbox_and_tag` used to take in ``obj_tags`` (:obj:`List[str]`) as an input
-        data type, which has been deprecated and now subsumed under ``obj_attrs``
-        (:obj:`Dict[str, Any]`). The same attribute is accessed by the ``groups`` key of
-        ``obj_attrs``.
+        :mod:`draw.group_bbox_and_tag` used to take in ``obj_tags``
+        (:obj:`List[str]`) as an input data type, which has been deprecated and
+        now subsumed under :term:`obj_attrs`. The same attribute is accessed by
+        the ``groups`` key of :term:`obj_attrs`.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -53,7 +53,7 @@ class Node(AbstractNode):
         tag (:obj:`str`): **default = "LARGE GROUP!"**. |br|
             The string message printed when a large group is detected.
 
-    .. versionchanged:: 1.2.0 |br|
+    .. versionchanged:: 1.2.0
         :mod:`draw.group_bbox_and_tag` used to take in ``obj_tags``
         (:obj:`List[str]`) as an input data type, which has been deprecated and
         now subsumed under :term:`obj_attrs`. The same attribute is accessed by

--- a/peekingduck/pipeline/nodes/draw/heat_map.py
+++ b/peekingduck/pipeline/nodes/draw/heat_map.py
@@ -32,12 +32,12 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     highlighted in blue.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |density_map|
+        |density_map_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/draw/heat_map.py
+++ b/peekingduck/pipeline/nodes/draw/heat_map.py
@@ -27,9 +27,9 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     """Superimposes a heat map over an image.
 
-    The ``draw.heat_map`` node helps to identify areas that are more crowded. Areas
-    that are more crowded are highlighted in red while areas that are less crowded are
-    highlighted in blue.
+    The :mod:`draw.heat_map` node helps to identify areas that are more
+    crowded. Areas that are more crowded are highlighted in red while areas
+    that are less crowded are highlighted in blue.
 
     Inputs:
         |img_data|

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -23,23 +23,25 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 
 
 class Node(AbstractNode):
-    """Draws a translucent legend box on a corner of the image, containing selected information
-    produced by preceding nodes in the format ``<data type>: <value>``. Supports in-built
-    PeekingDuck data types defined in :doc:`Glossary </glossary>` as well as custom data types
-    produced by custom nodes.
+    """Draws a translucent legend box on a corner of the image, containing
+    selected information produced by preceding nodes in the format
+    ``<data type>: <value>``. Supports in-built PeekingDuck data types defined
+    in :doc:`Glossary </glossary>` as well as custom data types produced by
+    custom nodes.
 
-    This example screenshot shows ``fps`` from :mod:`dabble.fps`, ``count`` from
-    :mod:`dabble.bbox_count` and ``cum_avg`` from :mod:`dabble.statistics` displayed within the
-    legend box.
+    This example screenshot shows :term:`fps` from :mod:`dabble.fps`,
+    :term:`count` from :mod:`dabble.bbox_count` and :term:`cum_avg` from
+    :mod:`dabble.statistics` displayed within the legend box.
 
     .. image:: /assets/api/legend.png
 
     |br|
 
-    With the exception of the ``zone_count`` data type from :mod:`dabble.zone_count`, all other
-    selected in-built PeekingDuck data types or custom data types must be of types :obj:`int`,
-    :obj:`float`, :obj:`str`. Note that values of float type such as ``fps`` and ``cum_avg`` are
-    displayed in 2 decimal places.
+    With the exception of the :term:`zone_count` data type from
+    :mod:`dabble.zone_count`, all other selected in-built PeekingDuck data
+    types or custom data types must be of types :obj:`int`, :obj:`float`, or
+    :obj:`str`. Note that values of float type such as :term:`fps` and
+    :term:`cum_avg` are displayed in 2 decimal places.
 
     Inputs:
         |all_input_data|
@@ -49,18 +51,20 @@ class Node(AbstractNode):
 
     Configs:
         position (:obj:`str`): **{"top", "bottom"}, default = "bottom"**. |br|
-            Position to draw legend box. "top" draws it at the top-left position while "bottom"
-            draws it at bottom-left.
+            Position to draw legend box. "top" draws it at the top-left
+            position while "bottom" draws it at bottom-left.
         show (:obj:`List[str]`): **default = []**. |br|
-            Include in this list the desired data type(s) to be drawn within the legend box, such
-            as ``["fps", "count", "cum_avg"]`` in the example screenshot. Custom data types
-            produced by custom nodes are also supported. If no data types are included, an error
-            will be produced.
+            Include in this list the desired data type(s) to be drawn within
+            the legend box, such as ``["fps", "count", "cum_avg"]`` in the
+            example screenshot. Custom data types produced by custom nodes are
+            also supported. If no data types are included, an error will be
+            produced.
 
     .. versionchanged:: 1.2.0
-        Merged previous ``all_legend_items`` and ``include`` configs into a single ``show`` config
-        for greater clarity. Added support for drawing custom data types produced by custom nodes,
-        to improve the flexibility of this node.
+        Merged previous ``all_legend_items`` and ``include`` configs into a
+        single ``show`` config for greater clarity. Added support for drawing
+        custom data types produced by custom nodes, to improve the flexibility
+        of this node.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -42,10 +42,10 @@ class Node(AbstractNode):
     displayed in 2 decimal places.
 
     Inputs:
-        |all_input|
+        |all_input_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         position (:obj:`str`): **{"top", "bottom"}, default = "bottom"**. |br|

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -31,12 +31,12 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     pixelating the areas bounded by bounding boxes in an image.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |img|
+        |img_data|
 
     Configs:
         mosaic_level (:obj:`int`): **default = 7**. |br|

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -27,7 +27,7 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     """Mosaics areas bounded by bounding boxes on image.
 
-    The ``draw.mosaic_bbox`` node helps to anonymize detected objects by
+    The :mod:`draw.mosaic_bbox` node helps to anonymize detected objects by
     pixelating the areas bounded by bounding boxes in an image.
 
     Inputs:
@@ -43,7 +43,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             Defines the resolution of a mosaic filter (width |times| height).
             The number corresponds to the number of rows and columns used to
             create a mosaic. For example, the default setting
-            (``mosaic_level = 7``) creates a 7 |times| 7 mosaic filter.
+            (``mosaic_level = 7``) creates a :math:`7 \\times 7` mosaic filter.
             Increasing the number increases the intensity of pixelation over an
             area.
     """

--- a/peekingduck/pipeline/nodes/draw/poses.py
+++ b/peekingduck/pipeline/nodes/draw/poses.py
@@ -25,10 +25,11 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Draws poses onto image.
 
-    The :mod:`draw.poses` node uses the ``keypoints``, ``keypoint_scores``, and
-    ``keypoint_conns`` predictions from pose models to draw the human poses
-    onto the image. For better understanding, check out the pose models such
-    as :mod:`HRNet <model.hrnet>` and :mod:`PoseNet <model.posenet>`.
+    The :mod:`draw.poses` node uses the :term:`keypoints`,
+    :term:`keypoint_scores`, and :term:`keypoint_conns` predictions from pose
+    models to draw the human poses onto the image. For better understanding,
+    check out the pose models such as :mod:`HRNet <model.hrnet>` and
+    :mod:`PoseNet <model.posenet>`.
 
     Inputs:
         |img_data|

--- a/peekingduck/pipeline/nodes/draw/poses.py
+++ b/peekingduck/pipeline/nodes/draw/poses.py
@@ -31,16 +31,16 @@ class Node(AbstractNode):
     as :mod:`HRNet <model.hrnet>` and :mod:`PoseNet <model.posenet>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |keypoints|
+        |keypoints_data|
 
-        |keypoint_scores|
+        |keypoint_scores_data|
 
-        |keypoint_conns|
+        |keypoint_conns_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -86,7 +86,7 @@ class Node(AbstractNode):
             Define the color of the drawn tag, in BGR format. Defined values
             have to be integers, and :math:`0 \\leq value \\leq 255`.
 
-    .. versionchanged:: 1.2.0 |br|
+    .. versionchanged:: 1.2.0
         :mod:`draw.tag` used to take in ``obj_tags`` (:obj:`List[str]`) as an
         input data type, which has been deprecated and now subsumed under
         :term:`obj_attrs`, giving this node more flexibility. Also, the

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -67,14 +67,14 @@ class Node(AbstractNode):
     +-----+-----------------------------------------+---------------+---------------+
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
-        |obj_attrs|
+        |obj_attrs_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         show (:obj:`List[str]`): **default = []**. |br|

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -13,52 +13,54 @@
 # limitations under the License.
 
 """
-Draws a tag (from ``obj_attrs``) above each bounding box
+Draws a tag (from :term:`obj_attrs`) above each bounding box
 """
 
 import copy
 from typing import Any, Dict, List
 
-from peekingduck.pipeline.nodes.draw.utils.bbox import draw_tags, check_bgr_type
+from peekingduck.pipeline.nodes.draw.utils.bbox import check_bgr_type, draw_tags
 from peekingduck.pipeline.nodes.node import AbstractNode
 
 
 class Node(AbstractNode):
-    """Draws a tag above each bounding box in the image, using information from selected attributes
-    in ``obj_attrs``. In the general example below, ``obj_attrs`` has 2 attributes (`<attr a>` and
-    `<attr b>`). There are `n` detected bounding boxes, and each attribute has `n` corresponding
-    tags stored in a list. The ``show`` config described subsequently is used to choose the
-    attribute or attributes to be drawn. ::
+    """Draws a tag above each bounding box in the image, using information from
+    selected attributes in :term:`obj_attrs`. In the general example below,
+    :term:`obj_attrs` has 2 attributes (`<attr a>` and `<attr b>`). There are
+    `n` detected bounding boxes, and each attribute has `n` corresponding tags
+    stored in a list. The ``show`` config described subsequently is used to
+    choose the attribute or attributes to be drawn. ::
 
         {"obj_attrs": {<attr a>: [<tag 1>, ..., <tag n>], <attr b>: [<tag 1>, ..., <tag n>]}}
 
     The following type conventions need to be observed:
 
-    * Each attribute must be of type :obj:`List`, e.g. ``<attr a>: [<tag 1>, ..., <tag n>]`` \
+        * Each attribute must be of type :obj:`List`, e.g.,
+          ``<attr a>: [<tag 1>, ..., <tag n>]``
+        * Each tag must be of type :obj:`str`, :obj:`int`, :obj:`float`, or
+          :obj:`bool` to be convertable into :obj:`str` type for drawing
 
-    * Each tag must be of type :obj:`str`, :obj:`int`, :obj:`float` or :obj:`bool` to be \
-    convertable into :obj:`str` type for drawing
-
-    In the example below, ``obj_attrs`` has 3 attributes (`"ids"`, `"gender"` and `"age"`), where
-    the last 2 attributes are nested within `"details"`. There are 2 detected bounding boxes, and
-    thus each attribute consists of a list with 2 tags. ::
+    In the example below, :term:`obj_attrs` has 3 attributes (`"ids"`,
+    `"gender"` and `"age"`), where the last 2 attributes are nested within
+    `"details"`. There are 2 detected bounding boxes, and thus each attribute
+    consists of a list with 2 tags. ::
 
         # Example
         {"obj_attrs": {"ids":[1,2], "details": {"gender": ["female","male"], "age": [52,17]}}
 
-    The table below illustrates how ``show`` can be configured to achieve different outcomes for
-    this example. Key takeaways are:
+    The table below illustrates how ``show`` can be configured to achieve
+    different outcomes for this example. Key takeaways are:
 
-    * To draw nested attributes, include all the keys leading to them (within the ``obj_attrs`` \
-    dictionary), separating each key with a ``->``. \
-
-    * To draw multiple comma-separated attributes above each bounding box, add them to the list \
-    of ``show`` config.
+        * To draw nested attributes, include all the keys leading to them
+          (within the :term:`obj_attrs` dictionary), separating each key with a
+          ``->``.
+        * To draw multiple comma-separated attributes above each bounding box,
+          add them to the list of ``show`` config.
 
     +-----+-----------------------------------------+---------------+---------------+
     | No. | ``show`` config                         | Tag above 1st | Tag above 2nd |
     |     |                                         | bounding box  | bounding box  |
-    +-----+-----------------------------------------+---------------+---------------+
+    +=====+=========================================+===============+===============+
     | 1.  | ["ids"]                                 | "1"           | "2"           |
     +-----+-----------------------------------------+---------------+---------------+
     | 2.  | ["details -> gender"]                   | "female"      | "male"        |
@@ -78,17 +80,18 @@ class Node(AbstractNode):
 
     Configs:
         show (:obj:`List[str]`): **default = []**. |br|
-            List the desired attributes to be drawn. For more details on how to use this config,
-            see the section above.
+            List the desired attributes to be drawn. For more details on how to
+            use this config, see the section above.
         tag_color (:obj:`List[int]`): **default = [77, 103, 255]**. |br|
-            Define the color of the drawn tag, in BGR format. Defined values have to be integers,
-            and 0 <= value <= 255.
+            Define the color of the drawn tag, in BGR format. Defined values
+            have to be integers, and :math:`0 \\leq value \\leq 255`.
 
     .. versionchanged:: 1.2.0 |br|
-        :mod:`draw.tag` used to take in ``obj_tags`` (:obj:`List[str]`) as an input data type,
-        which has been deprecated and now subsumed under ``obj_attrs`` (:obj:`Dict[str, Any]`),
-        giving this node more flexibility. Also, the ``tag_color`` config is added to provide
-        the option of changing the tag's color.
+        :mod:`draw.tag` used to take in ``obj_tags`` (:obj:`List[str]`) as an
+        input data type, which has been deprecated and now subsumed under
+        :term:`obj_attrs`, giving this node more flexibility. Also, the
+        ``tag_color`` config is added to provide the option of changing the
+        tag's color.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/draw/zones.py
+++ b/peekingduck/pipeline/nodes/draw/zones.py
@@ -30,12 +30,12 @@ class Node(AbstractNode):
     boundaries onto the image.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |zones|
+        |zones_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         None.

--- a/peekingduck/pipeline/nodes/draw/zones.py
+++ b/peekingduck/pipeline/nodes/draw/zones.py
@@ -25,7 +25,7 @@ from peekingduck.pipeline.nodes.node import AbstractNode
 class Node(AbstractNode):
     """Draws the boundaries of each specified zone onto the image.
 
-    The ``draw.zones`` node uses the ``zones`` output from the
+    The ``draw.zones`` node uses the :term:`zones` output from the
     ``dabble.zone_count`` node to draw a bounding box that represents the zone
     boundaries onto the image.
 

--- a/peekingduck/pipeline/nodes/input/live.py
+++ b/peekingduck/pipeline/nodes/input/live.py
@@ -27,16 +27,16 @@ class Node(AbstractNode):
     """Receives livestream as inputs.
 
     Inputs:
-        |no_input|
+        |none_input_data|
 
     Outputs:
-        |img|
+        |img_data|
 
-        |filename|
+        |filename_data|
 
-        |pipeline_end|
+        |pipeline_end_data|
 
-        |saved_video_fps|
+        |saved_video_fps_data|
 
     Configs:
         fps_saved_output_video (:obj:`int`): **default = 10**. |br|

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -53,9 +53,10 @@ class Node(AbstractNode):
             The FPS may increase if this is enabled (system dependent).
         buffer_frames (:obj:`bool`): **default = False**. |br|
             Boolean to indicate if threaded class should buffer image frames.
-            If threading is True, it is highly recommended that buffer_frames is
-            also True to avoid losing frames, as otherwise the input thread would
-            very likely read ahead of the main thread. |br|
+            If ``threading`` is ``True``, it is highly recommended that
+            ``buffer_frames`` is also ``True`` to avoid losing frames, as
+            otherwise the input thread would very likely read ahead of the main
+            thread. |br|
             For more info, please refer to `input.recorded configuration
             <https://github.com/aimakerspace/PeekingDuck/blob/dev/peekingduck/configs/input/recorded.yml>`_.
     """

--- a/peekingduck/pipeline/nodes/input/recorded.py
+++ b/peekingduck/pipeline/nodes/input/recorded.py
@@ -29,16 +29,16 @@ class Node(AbstractNode):
     """Receives videos/image as inputs.
 
     Inputs:
-        |no_input|
+        |none_input_data|
 
     Outputs:
-        |img|
+        |img_data|
 
-        |pipeline_end|
+        |pipeline_end_data|
 
-        |filename|
+        |filename_data|
 
-        |saved_video_fps|
+        |saved_video_fps_data|
 
     Configs:
         resize (:obj:`Dict`):

--- a/peekingduck/pipeline/nodes/model/csrnet.py
+++ b/peekingduck/pipeline/nodes/model/csrnet.py
@@ -33,12 +33,12 @@ class Node(AbstractNode):
     accurate if the number of people are low (e.g. less than 10)
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |density_map|
+        |density_map_data|
 
-        |count|
+        |count_data|
 
     Configs:
         model_type (:obj:`str`): **{"dense", "sparse"}, default="sparse"**. |br|

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -37,14 +37,14 @@ class Node(AbstractNode):
     changed to other values.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
     Configs:
         model_type (:obj:`int`): **{0, 1, 2, 3, 4}, default = 0**. |br|

--- a/peekingduck/pipeline/nodes/model/fairmot.py
+++ b/peekingduck/pipeline/nodes/model/fairmot.py
@@ -31,16 +31,16 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     re-identification tasks in an object tracker.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
-        |obj_attrs|
+        |obj_attrs_data|
 
     Configs:
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -50,8 +50,8 @@ class Node(AbstractNode):
 
     Configs:
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
-            Change the parent directory where weights will be stored by replacing
-            ``null`` with an absolute path to the desired directory.
+            Change the parent directory where weights will be stored by
+            replacing ``null`` with an absolute path to the desired directory.
         resolution (:obj:`Dict`):
             **default = { height: 192, width: 256 }**. |br|
             Resolution of input array to HRNet model.

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -37,16 +37,16 @@ class Node(AbstractNode):
     :ref:`here <whole-body-keypoint-ids>`.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |bboxes|
+        |bboxes_data|
 
     Outputs:
-        |keypoints|
+        |keypoints_data|
 
-        |keypoint_scores|
+        |keypoint_scores_data|
 
-        |keypoint_conns|
+        |keypoint_conns_data|
 
     Configs:
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -29,16 +29,16 @@ class Node(AbstractNode):
     shared neural network.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
-        |obj_attrs|
+        |obj_attrs_data|
 
     Configs:
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -52,10 +52,10 @@ class Node(AbstractNode):
             Object confidence score threshold.
         min_box_area (:obj:`int`): **default = 200**. |br|
             Minimum value for area of detected bounding box. Calculated by
-            width * height.
+            :math:`width \\times height`.
         track_buffer (:obj:`int`): **default = 30**. |br|
-            Threshold to remove track if track is lost for more frames
-            than value.
+            Threshold to remove track if track is lost for more frames than
+            value.
 
     References:
         Towards Real-Time Multi-Object Tracking:

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -36,17 +36,17 @@ class Node(AbstractNode):
     and the keypoint indices table can be found :ref:`here <whole-body-keypoint-ids>`.
 
     Inputs:
-        |img|
+        |img_data|
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |keypoints|
+        |keypoints_data|
 
-        |keypoint_scores|
+        |keypoint_scores_data|
 
-        |keypoint_conns|
+        |keypoint_conns_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
     Configs:
         model_type (:obj:`str`):

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -28,15 +28,18 @@ class Node(AbstractNode):
     """MoveNet node that initializes a MoveNet model to detect human poses from
     an image.
 
-    The MoveNet node is capable of detecting up to 6 human figures for multipose lightning and
-    single person for singlepose lightning/thunder. If there are more than 6 persons in the image,
-    multipose lightning will only detect 6. This also applies to singlepose models, where only 1
-    person will be detected in a multi persons image, do take note that detection performance
-    will suffer when using singlepose models on multi persons images. 17 keypoints are estimated
-    and the keypoint indices table can be found :ref:`here <whole-body-keypoint-ids>`.
+    The MoveNet node is capable of detecting up to 6 human figures for
+    multipose lightning and single person for singlepose lightning/thunder. If
+    there are more than 6 persons in the image, multipose lightning will only
+    detect 6. This also applies to singlepose models, where only 1 person will
+    be detected in a multi persons image, do take note that detection
+    performance will suffer when using singlepose models on multi persons
+    images. 17 keypoints are estimated and the keypoint indices table can be
+    found :ref:`here <whole-body-keypoint-ids>`.
 
     Inputs:
         |img_data|
+
     Outputs:
         |bboxes_data|
 
@@ -54,14 +57,15 @@ class Node(AbstractNode):
             singlepose_lightning", "singlepose_thunder", "multipose_lightning"
             },  default="multipose_lightning"** |br|
             Defines the detection model for MoveNet either single or multi pose.
-            Lightning is smaller and faster but less accurate than Thunder version.
+            Lightning is smaller and faster but less accurate than Thunder
+            version.
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
-            Change the parent directory where weights will be stored by replacing
-            ``null`` with an absolute path to the desired directory.
+            Change the parent directory where weights will be stored by
+            replacing ``null`` with an absolute path to the desired directory.
         resolution (:obj:`Dict`): **default = { height: 256, width: 256 }** |br|
             Dictionary of resolutions of input array to different MoveNet models.
-            Only multipose allows dynamic shape in multiples of 32 (recommended 256).
-            Default will be the resolution for multipose lightning model.
+            Only multipose allows dynamic shape in multiples of 32 (recommended
+            256). Default will be the resolution for multipose lightning model.
         bbox_score_threshold (:obj:`float`): **[0,1], default = 0.2** |br|
             Detected bounding box confidence score threshold, only boxes above
             threshold will be kept in the output.

--- a/peekingduck/pipeline/nodes/model/mtcnn.py
+++ b/peekingduck/pipeline/nodes/model/mtcnn.py
@@ -30,14 +30,14 @@ class Node(AbstractNode):
     faces with face masks (e.g. surgical masks).
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
     Configs:
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/posenet.py
+++ b/peekingduck/pipeline/nodes/model/posenet.py
@@ -31,18 +31,18 @@ class Node(AbstractNode):
     :ref:`here <whole-body-keypoint-ids>`.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |keypoints|
+        |keypoints_data|
 
-        |keypoint_scores|
+        |keypoint_scores_data|
 
-        |keypoint_conns|
+        |keypoint_conns_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
     Configs:
         model_type (:obj:`str`):

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -43,8 +43,8 @@ class Node(AbstractNode):
         model_type (:obj:`str`): **{"v4", "v4tiny"}, default="v4tiny"**. |br|
             Defines the type of YOLO model to be used.
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
-            Change the parent directory where weights will be stored by replacing
-            ``null`` with an absolute path to the desired directory.
+            Change the parent directory where weights will be stored by
+            replacing ``null`` with an absolute path to the desired directory.
         num_classes (:obj:`int`): **default = 80**. |br|
             Maximum number of objects to be detected.
         detect_ids (:obj:`List`): **default = [0]**. |br|
@@ -65,7 +65,8 @@ class Node(AbstractNode):
         YOLOv4: Optimal Speed and Accuracy of Object Detection:
         https://arxiv.org/pdf/2004.10934v1.pdf
 
-        Model weights trained by https://github.com/hunglc007/tensorflow-yolov4-tflite
+        Model weights trained by
+        https://github.com/hunglc007/tensorflow-yolov4-tflite
 
         Inference code adapted from https://github.com/zzh8829/yolov3-tf2
     """

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -30,14 +30,14 @@ class Node(AbstractNode):
     categories can be found :ref:`here <general-object-detection-ids>`.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
     Configs:
         model_type (:obj:`str`): **{"v4", "v4tiny"}, default="v4tiny"**. |br|

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -31,14 +31,14 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     faces with and without face masks.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
     Configs:
         model_type (:obj:`str`): **{"v4", "v4tiny"}, default="v4tiny"**. |br|

--- a/peekingduck/pipeline/nodes/model/yolo_license_plate.py
+++ b/peekingduck/pipeline/nodes/model/yolo_license_plate.py
@@ -29,14 +29,14 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     Plate). It uses YOLOv4-tiny by default and can be changed to using YOLOv4.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
     Configs:
         model_type (:obj:`str`): **{"v4", "v4tiny"}, default="v4"**. |br|

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -29,14 +29,14 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     ``("yolox-tiny", "yolox-s", "yolox-m", "yolox-l")``.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |bboxes|
+        |bboxes_data|
 
-        |bbox_labels|
+        |bbox_labels_data|
 
-        |bbox_scores|
+        |bbox_scores_data|
 
     Configs:
         model_type (:obj:`str`): **{"yolox-tiny", "yolox-s", "yolox-m",

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -24,9 +24,10 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     """Initializes and uses YOLOX to infer from an image frame.
 
     The YOLOX node is capable detecting objects from 80 categories. The table
-    of object categories can be found :ref:`here <general-object-detection-ids>`.
-    The ``"yolox-tiny"`` model is used by default and can be changed to one of
-    ``("yolox-tiny", "yolox-s", "yolox-m", "yolox-l")``.
+    of object categories can be found
+    :ref:`here <general-object-detection-ids>`. The ``"yolox-tiny"`` model is
+    used by default and can be changed to one of ``("yolox-tiny", "yolox-s",
+    "yolox-m", "yolox-l")``.
 
     Inputs:
         |img_data|
@@ -57,8 +58,9 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             Bounding boxes with confidence score (product of objectness score
             and classification score) below the threshold will be discarded.
         agnostic_nms (:obj:`bool`): **default = True**. |br|
-            Flag to determine if class agnostic NMS (torchvision.ops.nms) or
-            class aware NMS (torchvision.ops.batched_nms) should be used.
+            Flag to determine if class agnostic NMS (``torchvision.ops.nms``)
+            or class aware NMS (``torchvision.ops.batched_nms``) should be
+            used.
         half (:obj:`bool`): **default = False**. |br|
             Flag to determine if half-precision floating-point should be used
             for inference.

--- a/peekingduck/pipeline/nodes/output/csv_writer.py
+++ b/peekingduck/pipeline/nodes/output/csv_writer.py
@@ -35,7 +35,7 @@ class Node(AbstractNode):
         ``stats_to_track``.
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         stats_to_track (:obj:`List`):

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):
         |none_output_data|
 
     Configs:
-        output_dir (:obj:`str`): **default = 'PeekingDuck/data/output'**. |br|
+        output_dir (:obj:`str`): **default = "PeekingDuck/data/output"**. |br|
             Output directory for files to be written locally.
     """
 

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -36,16 +36,16 @@ class Node(AbstractNode):
     """Outputs the processed image or video to a file.
 
     Inputs:
-        |img|
+        |img_data|
 
-        |filename|
+        |filename_data|
 
-        |saved_video_fps|
+        |saved_video_fps_data|
 
-        |pipeline_end|
+        |pipeline_end_data|
 
     Outputs:
-        |no_output|
+        |none_output_data|
 
     Configs:
         output_dir (:obj:`str`): **default = 'PeekingDuck/data/output'**. |br|

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -37,12 +37,12 @@ class Node(AbstractNode):
             Name of the displayed window.
         window_size (:obj:`Dict`):
             **default = { do_resizing: False, width: 1280, height: 720 }** |br|
-            Resizes the displayed window to the chosen width and weight, if ``do_resizing``
-            is set to ``true``. The size of the displayed window can also be adjusted by
-            clicking and dragging.
+            Resizes the displayed window to the chosen width and weight, if
+            ``do_resizing`` is set to ``true``. The size of the displayed
+            window can also be adjusted by clicking and dragging.
         window_loc (:obj:`Dict`): **default = { x: 0, y: 0 }** |br|
-            X and Y coordinates of the top left corner of the displayed window, with
-            reference from the top left corner of the screen, in pixels.
+            X and Y coordinates of the top left corner of the displayed window,
+            with reference from the top left corner of the screen, in pixels.
     """
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -27,10 +27,10 @@ class Node(AbstractNode):
     """Streams the output on your display.
 
     Inputs:
-        |img|
+        |img_data|
 
     Outputs:
-        |pipeline_end|
+        |pipeline_end_data|
 
     Configs:
         window_name (:obj:`str`): **default = "PeekingDuck"** |br|


### PR DESCRIPTION
- Implement `glossary.rst` using sphinx glossary
  - Configs in docstrings need to use `|<data_type>_data|` for substitution now
- Replace glossary references to use `term` directive
- Change `deprecated` and `versionchanged` to show single change per directive