### PR TITLE
Fix: Convert BGR to RGB in YOLOv4

### DIFF
--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_files/detector.py
@@ -128,7 +128,7 @@ class Detector:
             - nums: number of valid bboxes. Only nums[0] should be used. The rest
                     are paddings.
         """
-        # image = image[..., ::-1]  # swap from bgr to rgb
+        image = image[..., ::-1]  # swap from bgr to rgb
         pred = self.yolo(image)[-1]
         bboxes = pred[:, :, :4].numpy()
         bboxes[:, :, [0, 1]] = bboxes[:, :, [1, 0]]  # swapping x and y axes


### PR DESCRIPTION
Uncommented line that will convert BGR to RGB in YOLOv4. This has been tested with the mAP evaluator to confirm results are correct and the YOLO model is in fact reading in RGB images.