### PR TITLE
bugfix: `input.visual` converter error for `input.live`/`input.recorded`

### DIFF
--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -107,8 +107,8 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
             if isinstance(node, str):
                 if node in ["input.live", "input.recorded"]:
                     deprecation_warning(node, "input.visual")
-                    node.replace("live", "visual")
-                    node.replace("recorded", "visual")
+                    node = node.replace("live", "visual")
+                    node = node.replace("recorded", "visual")
             else:
                 if "input.live" in node:
                     node_config = node.pop("input.live")


### PR DESCRIPTION
Fix crashing bug when node is just `input.live`/`input.recorded` with no configurations.
Bug caused by `node.replace("live", "visual")`, `node.replace("recorded", "visual")` as Python string replace is not in-place.