### PR TITLE
bugfix: 'input.visual' converter left out 'source:0' config

### DIFF
--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -107,8 +107,11 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
             if isinstance(node, str):
                 if node in ["input.live", "input.recorded"]:
                     deprecation_warning(node, "input.visual")
-                    node = node.replace("live", "visual")
-                    node = node.replace("recorded", "visual")
+                    if node == "input.live":
+                        node = {"input.visual": {"source": 0}}
+                    else:
+                        self.logger.error("input.recorded with no parameters error!")
+                        node = "input.visual"
             else:
                 if "input.live" in node:
                     node_config = node.pop("input.live")


### PR DESCRIPTION
`input.visual` converter left out `source:0` configuration for the deprecated `input.live`. This results in the green man video showing instead of the live webcam.
Also for anomalous `input.recorded` without configuration situation, will default to just `input.visual` which reads the green man video from PeekingDuck's cloud storage.