### PR TITLE
Fix read png windows bug and input visual progress

### DIFF
--- a/peekingduck/pipeline/nodes/input/utils/png_reader.py
+++ b/peekingduck/pipeline/nodes/input/utils/png_reader.py
@@ -1,0 +1,72 @@
+# Copyright 2022 AI Singapore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Custom PNG reader to fix opencv 'PNG magic' problem on Windows platform
+"""
+from typing import Any, Tuple
+import cv2
+import numpy as np
+
+
+class PNGReader:
+    """Custom PNG reader to fix opencv 'PNG magic' problem on Windows platform"""
+
+    def __init__(self, input_source: str) -> None:
+        self.img = cv2.imread(input_source)
+        self.height, self.width, _ = self.img.shape
+        self.get_map = {
+            cv2.CAP_PROP_FPS: 0,
+            cv2.CAP_PROP_FRAME_COUNT: 1,
+            cv2.CAP_PROP_FRAME_WIDTH: self.width,
+            cv2.CAP_PROP_FRAME_HEIGHT: self.height,
+        }
+        self.has_frames: bool = True
+
+    def get(self, param: Any) -> int:
+        """To mimic opencv's video capture object get(cv2.SOME_PROPERTY)
+
+        Args:
+            param (Any): cv2 property
+
+        Returns:
+            int: value of cv2 property if supported, otherwise -1
+        """
+        if param in self.get_map:
+            return self.get_map[param]
+        return -1
+
+    def isOpened(self) -> bool:  # pylint: disable=invalid-name, no-self-use
+        """To mimic opencv's video capture object isOpened()
+
+        Returns:
+            bool: always True
+        """
+        return True
+
+    def read(self) -> Tuple[bool, np.ndarray]:
+        """To mimic opencv's video capture object read()
+
+        Returns:
+            Tuple[bool, np.ndarray]: tuple of return status, image frame
+        """
+        if self.has_frames:
+            self.has_frames = False  # only 1 frame to read and return
+            return True, self.img
+        return False, self.img
+
+    def release(self) -> None:
+        """To mimic opencv's video capture object release().
+        Dummy method does nothing.
+        """

--- a/peekingduck/pipeline/nodes/input/utils/read.py
+++ b/peekingduck/pipeline/nodes/input/utils/read.py
@@ -25,6 +25,7 @@ from typing import Any, Tuple
 
 import cv2
 
+from peekingduck.pipeline.nodes.input.utils.png_reader import PNGReader
 from peekingduck.pipeline.nodes.input.utils.preprocess import mirror
 
 
@@ -40,13 +41,21 @@ class VideoThread:
             if str(input_source).isdigit():
                 # to eliminate opencv's "[WARN] terminating async callback"
                 self.stream = cv2.VideoCapture(input_source, cv2.CAP_DSHOW)
+            elif Path(input_source.lower()).suffix == ".png":
+                self.stream = PNGReader(input_source)
             else:
                 # no cv2.CAP_DSHOW flag if input_source is file
                 self.stream = cv2.VideoCapture(str(input_source))
         else:
-            self.stream = cv2.VideoCapture(
-                str(input_source) if isinstance(input_source, Path) else input_source
-            )
+            # Linux or macOS
+            if Path(input_source.lower()).suffix == ".png":
+                self.stream = PNGReader(input_source)
+            else:
+                self.stream = cv2.VideoCapture(
+                    str(input_source)
+                    if isinstance(input_source, Path)
+                    else input_source
+                )
         self.logger = logging.getLogger("VideoThread")
         self.mirror = mirror_image
         if not self.stream.isOpened():
@@ -173,18 +182,26 @@ class VideoNoThread:
     """
 
     def __init__(self, input_source: str, mirror_image: bool) -> None:
+        self.logger = logging.getLogger("VideoNoThread")
         if platform.system().startswith("Windows"):
             if str(input_source).isdigit():
                 # to eliminate opencv's "[WARN] terminating async callback"
                 self.stream = cv2.VideoCapture(input_source, cv2.CAP_DSHOW)
+            elif Path(input_source.lower()).suffix == ".png":
+                self.stream = PNGReader(input_source)
             else:
                 # no cv2.CAP_DSHOW flag if input_source is file
                 self.stream = cv2.VideoCapture(str(input_source))
         else:
-            self.stream = cv2.VideoCapture(
-                str(input_source) if isinstance(input_source, Path) else input_source
-            )
-        self.logger = logging.getLogger("VideoNoThread")
+            # Linux or macOS
+            if Path(input_source.lower()).suffix == ".png":
+                self.stream = PNGReader(input_source)
+            else:
+                self.stream = cv2.VideoCapture(
+                    str(input_source)
+                    if isinstance(input_source, Path)
+                    else input_source
+                )
         self.mirror = mirror_image
         if not self.stream.isOpened():
             raise ValueError(f"Video or image path incorrect: {input_source}")

--- a/peekingduck/pipeline/nodes/input/visual.py
+++ b/peekingduck/pipeline/nodes/input/visual.py
@@ -285,7 +285,7 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
         self.total_frame_count = (
             self.videocap.frame_count if self.videocap.frame_count > 0 else 0
         )
-        self.frame_counter: int = 0  # reset for newly opened input
+        self.frame_counter = 0  # reset for newly opened input
         self._progress_tenth: int = 1  # each 10% progress
         # check resizing configuration
         width, height = self.videocap.resolution

--- a/tests/pipeline/nodes/input/test_visual.py
+++ b/tests/pipeline/nodes/input/test_visual.py
@@ -119,18 +119,26 @@ class TestMediaReader:
         assert np.array_equal(read_video2, video2)
 
     def test_input_folder_of_mixed_media(self, create_input_image, create_input_video):
-        """Test read a folder of mixed media files: jpg, png, avi,
-        and verifying progress log messages"""
+        """Test read a folder of mixed media files: images and videos, and verifying
+        progress log messages
+        """
         size = (640, 480, 3)
+        test_filenames = [
+            "test_image_1.jpg",
+            "test_image_2.png",
+            "test_image_3.png",
+            "test_video_1.avi",
+            "test_video_2.avi",
+        ]
         contents = {
-            "img1": create_input_image("mix_image1.jpg", size),
-            "img2": create_input_image("mix_image2.png", size),
-            "img3": create_input_image("mix_image3.png", size),
+            "img1": create_input_image(test_filenames[0], size),
+            "img2": create_input_image(test_filenames[1], size),
+            "img3": create_input_image(test_filenames[2], size),
             # NB: be sure to sync number of frames with 'key_frames'!
             "vid_30": create_input_video(
-                "mix_video1.avi", fps=10, nframes=30, size=size
+                test_filenames[3], fps=10, nframes=30, size=size
             ),
-            "vid_3": create_input_video("mix_video2.avi", fps=1, nframes=3, size=size),
+            "vid_3": create_input_video(test_filenames[4], fps=1, nframes=3, size=size),
         }
         msg_set = set()
         with TestCase.assertLogs("peekingduck.pipeline.nodes.input.visual") as captured:
@@ -143,6 +151,7 @@ class TestMediaReader:
                     for _ in range(num_frames):
                         reader.run({})
                 else:
+                    print(f"read {k}")
                     reader.run({})
             reader.run({})  # run last pipeline iteration
 
@@ -153,6 +162,6 @@ class TestMediaReader:
         print(msg_set)
         assert "Approximate Progress: 33%" in msg_set
         assert "Approximate Progress: 100%" in msg_set
-        assert "Completed processing file: mix_image1.jpg (1 / 5)" in msg_set
-        assert "Completed processing file: mix_image3.png (3 / 5)" in msg_set
-        assert "Completed processing file: mix_video2.avi (5 / 5)" in msg_set
+        assert f"Completed processing file: {test_filenames[0]} (1 / 5)" in msg_set
+        assert f"Completed processing file: {test_filenames[2]} (3 / 5)" in msg_set
+        assert f"Completed processing file: {test_filenames[4]} (5 / 5)" in msg_set

--- a/tests/pipeline/nodes/input/test_visual.py
+++ b/tests/pipeline/nodes/input/test_visual.py
@@ -150,6 +150,7 @@ class TestMediaReader:
                 msg = record.getMessage()
                 msg_set.add(msg)
 
+        print(msg_set)
         assert "Approximate Progress: 33%" in msg_set
         assert "Approximate Progress: 100%" in msg_set
         assert "Completed processing file: mix_image1.jpg (1 / 5)" in msg_set


### PR DESCRIPTION
Updates to fix `input.visual` progress for a folder of multiple files.
Also updated input backend classes to fix opencv “bug” on Windows platform when dealing with numbered PNG file names.