### PR TITLE
Weights download: tqdm to stdout

### DIFF
--- a/peekingduck/weights_utils/downloader.py
+++ b/peekingduck/weights_utils/downloader.py
@@ -17,6 +17,7 @@ Functions to download model weights.
 """
 
 import os
+import sys
 import zipfile
 from pathlib import Path
 
@@ -39,7 +40,9 @@ def download_weights(weights_dir: Path, blob_file: str) -> None:
 
     # search for downloaded .zip file and extract, then delete
     with zipfile.ZipFile(zip_path, "r") as temp:
-        for file in tqdm(iterable=temp.namelist(), total=len(temp.namelist())):
+        for file in tqdm(
+            file=sys.stdout, iterable=temp.namelist(), total=len(temp.namelist())
+        ):
             temp.extract(member=file, path=weights_dir)
 
     os.remove(zip_path)
@@ -71,6 +74,6 @@ def save_response_content(response: requests.Response, destination: Path) -> Non
     chunk_size = 32768
 
     with open(destination, "wb") as temp:
-        for chunk in tqdm(response.iter_content(chunk_size)):
+        for chunk in tqdm(response.iter_content(chunk_size), file=sys.stdout):
             if chunk:  # filter out keep-alive new chunks
                 temp.write(chunk)


### PR DESCRIPTION
`tqdm` used by weights downloader outputs to `stderr` by default. This is fine for CLI usage.
However, for an app that `imports peekingduck...` and redirects `stderr` to monitor for errors, like PeekingDuckStudio for instance, then this is less than desirable, as:
1. The weights download output never appears for the user to see;
2. The app mistakes the weights download output in `stderr` stream for actual error messages.

Raise this PR to redirect `tqdm`'s output to use `stdout` instead of `stderr` to avoid the above problems.