### PR TITLE
Fix: create custom node directory relative to `src/`

### DIFF
--- a/peekingduck/cli.py
+++ b/peekingduck/cli.py
@@ -174,11 +174,11 @@ def create_node(
         node_subdir = verify_option(node_subdir, value_proc=ensure_relative_path)
         if node_subdir is None:
             node_subdir = click.prompt(
-                f"Enter node directory relative to {project_dir}",
-                default="src/custom_nodes",
+                f"Enter node directory relative to {project_dir}/src",
+                default="custom_nodes",
                 value_proc=ensure_relative_path,
             )
-        node_dir = project_dir / node_subdir
+        node_dir = project_dir / "src" / node_subdir
 
         node_type = verify_option(
             node_type, value_proc=ensure_valid_type_partial(node_type_choices)

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-from logging import LogRecord
 from pathlib import Path
 from unittest import TestCase
 

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -86,8 +86,8 @@ def get_custom_node_subpaths(node_subdir, node_type, node_name):
 
 def setup_custom_node(node_subdir, node_type, node_name):
     cwd = Path.cwd()
-    config_dir = cwd / node_subdir / "configs" / node_type
-    script_dir = cwd / node_subdir / node_type
+    config_dir = cwd / "src" / node_subdir / "configs" / node_type
+    script_dir = cwd / "src" / node_subdir / node_type
     config_dir.mkdir(parents=True, exist_ok=True)
     script_dir.mkdir(parents=True, exist_ok=True)
 
@@ -165,8 +165,10 @@ class TestCliCreateNode:
         node_type = good_type.strip()
         node_name = good_name.strip()
         cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
+        config_path = (
+            cwd / "src" / node_subdir / "configs" / node_type / f"{node_name}.yml"
+        )
+        script_path = cwd / "src" / node_subdir / node_type / f"{node_name}.py"
         assert config_path.exists()
         assert script_path.exists()
 
@@ -206,8 +208,10 @@ class TestCliCreateNode:
         assert result.output.count("Node name already exists!") == 1
 
         cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name_2}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name_2}.py"
+        config_path = (
+            cwd / "src" / node_subdir / "configs" / node_type / f"{node_name_2}.yml"
+        )
+        script_path = cwd / "src" / node_subdir / node_type / f"{node_name_2}.py"
         assert config_path.exists()
         assert script_path.exists()
 
@@ -293,8 +297,10 @@ class TestCliCreateNode:
         assert result.output.count("Created node!") == 1
 
         cwd = Path.cwd()
-        config_path = cwd / node_subdir / "configs" / node_type / f"{node_name}.yml"
-        script_path = cwd / node_subdir / node_type / f"{node_name}.py"
+        config_path = (
+            cwd / "src" / node_subdir / "configs" / node_type / f"{node_name}.yml"
+        )
+        script_path = cwd / "src" / node_subdir / node_type / f"{node_name}.py"
         assert config_path.exists()
         assert script_path.exists()
 


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/78

Forces the custom node directory to be relative to `path/to/pkd-project/src`