### PR TITLE
Feat: threshold checker interval string

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -2,6 +2,7 @@ click == 7.1.2
 colorama == 0.4.4
 numpy == 1.17.3
 opencv-contrib-python >= 4.5.2.54
+protobuf <= 3.20.1
 pyyaml >= 5.3
 requests == 2.24.0
 tensorflow == 2.2.0

--- a/peekingduck/pipeline/nodes/augment/brightness.py
+++ b/peekingduck/pipeline/nodes/augment/brightness.py
@@ -46,7 +46,7 @@ class Node(ThresholdCheckerMixin, AbstractNode):
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
 
-        self.check_bounds("beta", (-100, 100), "within")
+        self.check_bounds("beta", "[-100, 100]")
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Adjusts the brightness of an image frame.

--- a/peekingduck/pipeline/nodes/augment/contrast.py
+++ b/peekingduck/pipeline/nodes/augment/contrast.py
@@ -44,7 +44,7 @@ class Node(ThresholdCheckerMixin, AbstractNode):
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
 
-        self.check_bounds("alpha", (0, 3), "within")
+        self.check_bounds("alpha", "[0, 3]")
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Adjusts the contrast of an image frame.

--- a/peekingduck/pipeline/nodes/base.py
+++ b/peekingduck/pipeline/nodes/base.py
@@ -29,8 +29,6 @@ from tqdm import tqdm
 BASE_URL = "https://storage.googleapis.com/peekingduck/models"
 PEEKINGDUCK_WEIGHTS_SUBDIR = "peekingduck_weights"
 
-Number = Union[float, int]
-
 
 class ThresholdCheckerMixin:
     """Mixin class providing utility methods for checking validity of config
@@ -129,8 +127,8 @@ class ThresholdCheckerMixin:
     def _check_within_bounds(  # pylint: disable=too-many-arguments
         self,
         key: Union[str, List[str]],
-        lower: Number,
-        upper: Number,
+        lower: float,
+        upper: float,
         lower_openness: str,
         upper_openness: str,
     ) -> None:
@@ -139,8 +137,8 @@ class ThresholdCheckerMixin:
 
         Args:
             key (Union[str, List[str]]): The specified key or list of keys.
-            lower (Number): The lower bound.
-            upper (Number): The upper bound.
+            lower (float): The lower bound.
+            upper (float): The upper bound.
             lower_openness (str): Either a "(" for an open lower bound or a "["
                 for a closed lower bound.
             upper_openness (str): Either a ")" for an open upper bound or a "]"

--- a/peekingduck/pipeline/nodes/base.py
+++ b/peekingduck/pipeline/nodes/base.py
@@ -21,7 +21,7 @@ import re
 import sys
 import zipfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import requests
 from tqdm import tqdm

--- a/peekingduck/pipeline/nodes/base.py
+++ b/peekingduck/pipeline/nodes/base.py
@@ -96,14 +96,14 @@ class ThresholdCheckerMixin:
         if self.interval_pattern.match(interval) is None:
             raise ValueError("Badly formatted interval")
 
-        lower_openness = interval[0]
-        upper_openness = interval[-1]
+        left_bracket = interval[0]
+        right_bracket = interval[-1]
         lower, upper = [float(value.strip()) for value in interval[1:-1].split(",")]
 
         if lower > upper:
             raise ValueError("Lower bound cannot be larger than upper bound")
 
-        self._check_within_bounds(key, lower, upper, lower_openness, upper_openness)
+        self._check_within_bounds(key, lower, upper, left_bracket, right_bracket)
 
     def check_valid_choice(
         self, key: str, choices: Set[Union[int, float, str]]
@@ -129,8 +129,8 @@ class ThresholdCheckerMixin:
         key: Union[str, List[str]],
         lower: float,
         upper: float,
-        lower_openness: str,
-        upper_openness: str,
+        left_bracket: str,
+        right_bracket: str,
     ) -> None:
         """Checks that configuration values specified by `key` is within the
         specified bounds between `lower` and `upper`.
@@ -139,9 +139,9 @@ class ThresholdCheckerMixin:
             key (Union[str, List[str]]): The specified key or list of keys.
             lower (float): The lower bound.
             upper (float): The upper bound.
-            lower_openness (str): Either a "(" for an open lower bound or a "["
+            left_bracket (str): Either a "(" for an open lower bound or a "["
                 for a closed lower bound.
-            upper_openness (str): Either a ")" for an open upper bound or a "]"
+            right_bracket (str): Either a ")" for an open upper bound or a "]"
                 for a closed upper bound.
 
         Raises:
@@ -149,9 +149,9 @@ class ThresholdCheckerMixin:
             ValueError: If the configuration value is not between `lower` and
                 `upper`.
         """
-        method_lower = operator.ge if lower_openness == "[" else operator.gt
-        method_upper = operator.le if upper_openness == "]" else operator.lt
-        reason = f"between {lower_openness}{lower}, {upper}{upper_openness}"
+        method_lower = operator.ge if left_bracket == "[" else operator.gt
+        method_upper = operator.le if right_bracket == "]" else operator.lt
+        reason = f"between {left_bracket}{lower}, {upper}{right_bracket}"
         self._compare(key, lower, method_lower, reason)
         self._compare(key, upper, method_upper, reason)
 

--- a/peekingduck/pipeline/nodes/model/csrnetv1/csrnet_model.py
+++ b/peekingduck/pipeline/nodes/model/csrnetv1/csrnet_model.py
@@ -35,7 +35,7 @@ class CSRNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds("width", 0, "above", include=None)
+        self.check_bounds("width", "(0, +inf]")
 
         model_dir = self.download_weights()
         self.predictor = Predictor(

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
@@ -39,7 +39,7 @@ class EfficientDetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.logger = logging.getLogger(__name__)
 
         self.check_valid_choice("model_type", {0, 1, 2, 3, 4})
-        self.check_bounds("score_threshold", (0, 1), "within")
+        self.check_bounds("score_threshold", "[0, 1]")
 
         model_dir = self.download_weights()
         classes_path = model_dir / self.weights["classes_file"]

--- a/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_model.py
+++ b/peekingduck/pipeline/nodes/model/fairmotv1/fairmot_model.py
@@ -63,10 +63,8 @@ class FairMOTModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds(
-            ["K", "min_box_area", "track_buffer"], 0, "above", include=None
-        )
-        self.check_bounds("score_threshold", (0, 1), "within")
+        self.check_bounds(["K", "min_box_area", "track_buffer"], "(0, +inf]")
+        self.check_bounds("score_threshold", "[0, 1]")
 
         model_dir = self.download_weights()
         self.tracker = Tracker(

--- a/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
+++ b/peekingduck/pipeline/nodes/model/hrnetv1/hrnet_model.py
@@ -33,7 +33,7 @@ class HRNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds("score_threshold", (0, 1), "within")
+        self.check_bounds("score_threshold", "[0, 1]")
 
         model_dir = self.download_weights()
         self.detector = Detector(

--- a/peekingduck/pipeline/nodes/model/jdev1/jde_model.py
+++ b/peekingduck/pipeline/nodes/model/jdev1/jde_model.py
@@ -65,7 +65,7 @@ class JDEModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.logger = logging.getLogger(__name__)
 
         self.check_bounds(
-            ["iou_threshold", "nms_threshold", "score_threshold"], (0, 1), "within"
+            ["iou_threshold", "nms_threshold", "score_threshold"], "[0, 1]"
         )
 
         model_dir = self.download_weights()

--- a/peekingduck/pipeline/nodes/model/movenetv1/movenet_model.py
+++ b/peekingduck/pipeline/nodes/model/movenetv1/movenet_model.py
@@ -38,7 +38,7 @@ class MoveNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             {"singlepose_lightning", "singlepose_thunder", "multipose_lightning"},
         )
         self.check_bounds(
-            ["bbox_score_threshold", "keypoint_score_threshold"], (0, 1), "within"
+            ["bbox_score_threshold", "keypoint_score_threshold"], "[0, 1]"
         )
 
         model_dir = self.download_weights()

--- a/peekingduck/pipeline/nodes/model/mtcnnv1/mtcnn_model.py
+++ b/peekingduck/pipeline/nodes/model/mtcnnv1/mtcnn_model.py
@@ -35,9 +35,9 @@ class MTCNNModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds("min_size", 0, "above", include=None)
+        self.check_bounds("min_size", "(0, +inf]")
         self.check_bounds(
-            ["network_thresholds", "scale_factor", "score_threshold"], (0, 1), "within"
+            ["network_thresholds", "scale_factor", "score_threshold"], "[0, 1]"
         )
 
         model_dir = self.download_weights()

--- a/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
+++ b/peekingduck/pipeline/nodes/model/posenetv1/posenet_model.py
@@ -38,7 +38,7 @@ class PoseNetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.logger = logging.getLogger(__name__)
 
         self.check_valid_choice("model_type", {50, 75, 100, "resnet"})
-        self.check_bounds("score_threshold", (0, 1), "within")
+        self.check_bounds("score_threshold", "[0, 1]")
 
         model_dir = self.download_weights()
         self.predictor = Predictor(

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
@@ -33,7 +33,7 @@ class YOLOModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds(["iou_threshold", "score_threshold"], (0, 1), "within")
+        self.check_bounds(["iou_threshold", "score_threshold"], "[0, 1]")
 
         model_dir = self.download_weights()
         with open(model_dir / self.weights["classes_file"]) as infile:

--- a/peekingduck/pipeline/nodes/model/yolov4_face/yolo_face_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4_face/yolo_face_model.py
@@ -35,7 +35,7 @@ class YOLOFaceModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds(["iou_threshold", "score_threshold"], (0, 1), "within")
+        self.check_bounds(["iou_threshold", "score_threshold"], "[0, 1]")
 
         model_dir = self.download_weights()
         with open(model_dir / self.weights["classes_file"]) as infile:

--- a/peekingduck/pipeline/nodes/model/yolov4_license_plate/yolo_license_plate_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4_license_plate/yolo_license_plate_model.py
@@ -37,7 +37,7 @@ class YOLOLicensePlateModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds(["iou_threshold", "score_threshold"], (0, 1), "within")
+        self.check_bounds(["iou_threshold", "score_threshold"], "[0, 1]")
 
         model_dir = self.download_weights()
         with open(model_dir / self.weights["classes_file"]) as infile:

--- a/peekingduck/pipeline/nodes/model/yoloxv1/yolox_model.py
+++ b/peekingduck/pipeline/nodes/model/yoloxv1/yolox_model.py
@@ -47,7 +47,7 @@ class YOLOXModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        self.check_bounds(["iou_threshold", "score_threshold"], (0, 1), "within")
+        self.check_bounds(["iou_threshold", "score_threshold"], "[0, 1]")
 
         model_dir = self.download_weights()
         with open(model_dir / self.weights["classes_file"]) as infile:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click == 7.1.2
 colorama == 0.4.4
 numpy >= 1.17.3
 opencv-contrib-python >= 4.5.2.54
+protobuf <= 3.20.1
 pyyaml >= 5.3
 requests == 2.24.0
 tensorflow >= 2.2, < 2.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     click == 7.1.2
     requests == 2.24
     opencv-contrib-python >= 4.5.2.54
+    protobuf <= 3.20.1
     tensorflow >= 2.2, <2.8
     numpy >= 1.17.3
     tqdm == 4.45.0

--- a/tests/pipeline/nodes/augment/test_brightness.py
+++ b/tests/pipeline/nodes/augment/test_brightness.py
@@ -88,8 +88,8 @@ class TestBrightness:
     def test_beta_range(self):
         with pytest.raises(ValueError) as excinfo:
             Node({"input": ["img"], "output": ["img"], "beta": -101})
-        assert str(excinfo.value) == "beta must be between [-100, 100]"
+        assert str(excinfo.value) == "beta must be between [-100.0, 100.0]"
 
         with pytest.raises(ValueError) as excinfo:
             Node({"input": ["img"], "output": ["img"], "beta": 101})
-        assert str(excinfo.value) == "beta must be between [-100, 100]"
+        assert str(excinfo.value) == "beta must be between [-100.0, 100.0]"

--- a/tests/pipeline/nodes/augment/test_contrast.py
+++ b/tests/pipeline/nodes/augment/test_contrast.py
@@ -62,8 +62,8 @@ class TestContrast:
     def test_beta_range(self):
         with pytest.raises(ValueError) as excinfo:
             Node({"input": ["img"], "output": ["img"], "alpha": -0.5})
-        assert str(excinfo.value) == "alpha must be between [0, 3]"
+        assert str(excinfo.value) == "alpha must be between [0.0, 3.0]"
 
         with pytest.raises(ValueError) as excinfo:
             Node({"input": ["img"], "output": ["img"], "alpha": 3.1})
-        assert str(excinfo.value) == "alpha must be between [0, 3]"
+        assert str(excinfo.value) == "alpha must be between [0.0, 3.0]"

--- a/tests/pipeline/nodes/base/test_threshold_checker_mixin.py
+++ b/tests/pipeline/nodes/base/test_threshold_checker_mixin.py
@@ -98,6 +98,10 @@ class TestThresholdCheckerMixin:
             threshold_model.check_bounds("a", "[14, -inf]")
         assert "Lower bound cannot be larger than upper bound" == str(excinfo.value)
 
+        with pytest.raises(ValueError) as excinfo:
+            threshold_model.check_bounds("a", "[+inf, -inf]")
+        assert "Lower bound cannot be larger than upper bound" == str(excinfo.value)
+
     @pytest.mark.parametrize("include", [")", "]"])
     def test_threshold_above_value(self, threshold_model, include):
         with not_raises(ValueError):

--- a/tests/pipeline/nodes/base/test_threshold_checker_mixin.py
+++ b/tests/pipeline/nodes/base/test_threshold_checker_mixin.py
@@ -29,419 +29,418 @@ class ThresholdModel(ThresholdCheckerMixin):
 
 
 class TestThresholdCheckerMixin:
-    @pytest.mark.parametrize("include", ["lower", "both"])
+    def test_check_bounds_invalid_type(self, threshold_model):
+        with pytest.raises(TypeError) as excinfo:
+            threshold_model.check_bounds({"key1": "a"}, "[10, +inf]")
+        assert "`key` must be either str or list" == str(excinfo.value)
+
+    def test_check_bounds_bad_format(self, threshold_model):
+        with pytest.raises(ValueError) as excinfo:
+            # missing separator
+            threshold_model.check_bounds("a", "[13 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong separator
+            threshold_model.check_bounds("a", "[13; 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # missing left bracket
+            threshold_model.check_bounds("a", "13, 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # missing right bracket
+            threshold_model.check_bounds("a", "[13, 14")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong left bracket
+            threshold_model.check_bounds("a", "{13, 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong right bracket
+            threshold_model.check_bounds("a", "[13, 14}")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong right bracket
+            threshold_model.check_bounds("a", "[13, 14}")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong left value
+            threshold_model.check_bounds("a", "[value, 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong left value
+            threshold_model.check_bounds("a", "[1 2, 14]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            # wrong right value
+            threshold_model.check_bounds("a", "[13, 14.5.6]")
+        assert "Badly formatted interval" == str(excinfo.value)
+
+    def test_check_bounds_invalid_interval(self, threshold_model):
+        with pytest.raises(ValueError) as excinfo:
+            threshold_model.check_bounds("a", "[14, 13]")
+        assert "Lower bound cannot be larger than upper bound" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            threshold_model.check_bounds("a", "[+inf, 13]")
+        assert "Lower bound cannot be larger than upper bound" == str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            threshold_model.check_bounds("a", "[14, -inf]")
+        assert "Lower bound cannot be larger than upper bound" == str(excinfo.value)
+
+    @pytest.mark.parametrize("include", [")", "]"])
     def test_threshold_above_value(self, threshold_model, include):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", 9, "above", include)
+            threshold_model.check_bounds("a", f"[9, +inf{include}")
             # single value, inclusive
-            threshold_model.check_bounds("a", 12, "above", include)
+            threshold_model.check_bounds("a", f"[12, +inf{include}")
             # multiple values
-            threshold_model.check_bounds(["a", "b", "d"], 9, "above", include)
+            threshold_model.check_bounds(["a", "b", "d"], f"[9, +inf{include}")
             # multiple values, inclusive
-            threshold_model.check_bounds(["a", "b", "d"], 10, "above", include)
+            threshold_model.check_bounds(["a", "b", "d"], f"[10, +inf{include}")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail
-            threshold_model.check_bounds("a", 13, "above", include)
-        assert "a must be more than or equal to 13" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"[13, +inf{include}")
+        assert f"a must be between [13.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail first
-            threshold_model.check_bounds(["a", "b"], 13, "above", include)
-        assert "a must be more than or equal to 13" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"[13, +inf{include}")
+        assert f"a must be between [13.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail second
-            threshold_model.check_bounds(["a", "b"], 11, "above", include)
-        assert "b must be more than or equal to 11" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"[11, +inf{include}")
+        assert f"b must be between [11.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail second
-            threshold_model.check_bounds(["a", "d"], 11, "above", include)
-        assert "All elements of d must be more than or equal to 11" == str(
+            threshold_model.check_bounds(["a", "d"], f"[11, +inf{include}")
+        assert f"All elements of d must be between [11.0, inf{include}" == str(
             excinfo.value
         )
 
-    @pytest.mark.parametrize("include", ["upper", None])
+    @pytest.mark.parametrize("include", [")", "]"])
     def test_threshold_above_value_exclusive(self, threshold_model, include):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", 9, "above", include)
+            threshold_model.check_bounds("a", f"(9, +inf{include}")
             # multiple values
-            threshold_model.check_bounds(["a", "b"], 9, "above", include)
+            threshold_model.check_bounds(["a", "b"], f"(9, +inf{include}")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive, fail
-            threshold_model.check_bounds("a", 12.5, "above", include)
-        assert "a must be more than 12.5" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"(12.5, +inf{include}")
+        assert f"a must be between (12.5, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail
-            threshold_model.check_bounds("a", 13, "above", include)
-        assert "a must be more than 13" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"(13, +inf{include}")
+        assert f"a must be between (13.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail
-            threshold_model.check_bounds("d", 13, "above", include)
-        assert "All elements of d must be more than 13" == str(excinfo.value)
+            threshold_model.check_bounds("d", f"(13, +inf{include}")
+        assert f"All elements of d must be between (13.0, inf{include}" == str(
+            excinfo.value
+        )
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive, fail first
-            threshold_model.check_bounds(["a", "b"], 12.5, "above", include)
-        assert "a must be more than 12.5" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"(12.5, +inf{include}")
+        assert f"a must be between (12.5, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive, fail second
-            threshold_model.check_bounds(["a", "b"], 10, "above", include)
-        assert "b must be more than 10" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"(10, +inf{include}")
+        assert f"b must be between (10.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail first
-            threshold_model.check_bounds(["a", "b"], 13, "above", include)
-        assert "a must be more than 13" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"(13, +inf{include}")
+        assert f"a must be between (13.0, inf{include}" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail second
-            threshold_model.check_bounds(["a", "b"], 11, "above", include)
-        assert "b must be more than 11" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], f"(11, +inf{include}")
+        assert f"b must be between (11.0, inf{include}" == str(excinfo.value)
 
-    def test_threshold_above_value_invalid_type(self, threshold_model):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds({"key1": "a"}, 10, "above")
-        assert "`key` must be either str or list" == str(excinfo.value)
-
-    @pytest.mark.parametrize("include", ["upper", "both"])
+    @pytest.mark.parametrize("include", ["(", "["])
     def test_threshold_below_value(self, threshold_model, include):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", 13, "below", include)
+            threshold_model.check_bounds("a", f"{include}-inf, 13]")
             # single value, inclusive
-            threshold_model.check_bounds("a", 12.5, "below", include)
+            threshold_model.check_bounds("a", f"{include}-inf, 12.5]")
             # multiple values
-            threshold_model.check_bounds(["b", "a"], 13, "below", include)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 13]")
             # multiple values, inclusive
-            threshold_model.check_bounds(["b", "a"], 12.5, "below", include)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 12.5]")
             # multiple values, inclusive
-            threshold_model.check_bounds(["b", "a", "d"], 13, "below", include)
+            threshold_model.check_bounds(["b", "a", "d"], f"{include}-inf, 13]")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail
-            threshold_model.check_bounds("a", 12, "below", include)
-        assert "a must be less than or equal to 12" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"{include}-inf, 12]")
+        assert f"a must be between {include}-inf, 12.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail first
-            threshold_model.check_bounds(["b", "a"], 9, "below", include)
-        assert "b must be less than or equal to 9" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 9]")
+        assert f"b must be between {include}-inf, 9.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail second
-            threshold_model.check_bounds(["b", "a"], 11, "below", include)
-        assert "a must be less than or equal to 11" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 11]")
+        assert f"a must be between {include}-inf, 11.0]" == str(excinfo.value)
 
-    @pytest.mark.parametrize("include", ["lower", None])
+    @pytest.mark.parametrize("include", ["(", "["])
     def test_threshold_below_value_exclusive(self, threshold_model, include):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", 13, "below", include)
+            threshold_model.check_bounds("a", f"{include}-inf, 13)")
             # multiple values
-            threshold_model.check_bounds(["a", "b"], 13, "below", include)
+            threshold_model.check_bounds(["a", "b"], f"{include}-inf, 13)")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive, fail
-            threshold_model.check_bounds("a", 12.5, "below", include)
-        assert "a must be less than 12.5" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"{include}-inf, 12.5)")
+        assert f"a must be between {include}-inf, 12.5)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive, fail
-            threshold_model.check_bounds("d", 13, "below", include)
-        assert "All elements of d must be less than 13" == str(excinfo.value)
+            threshold_model.check_bounds("d", f"{include}-inf, 13)")
+        assert f"All elements of d must be between {include}-inf, 13.0)" == str(
+            excinfo.value
+        )
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail
-            threshold_model.check_bounds("a", 12, "below", include)
-        assert "a must be less than 12" == str(excinfo.value)
+            threshold_model.check_bounds("a", f"{include}-inf, 12)")
+        assert f"a must be between {include}-inf, 12.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive, fail first
-            threshold_model.check_bounds(["b", "a"], 9, "below", include)
-        assert "b must be less than 9" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 9)")
+        assert f"b must be between {include}-inf, 9.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive, fail second
-            threshold_model.check_bounds(["b", "a"], 12, "below", include)
-        assert "a must be less than 12" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 12)")
+        assert f"a must be between {include}-inf, 12.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail first
-            threshold_model.check_bounds(["b", "a"], 9, "below", include)
-        assert "b must be less than 9" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 9)")
+        assert f"b must be between {include}-inf, 9.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail second
-            threshold_model.check_bounds(["b", "a"], 12, "below", include)
-        assert "a must be less than 12" == str(excinfo.value)
-
-    def test_threshold_below_value_invalid_type(self, threshold_model):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds({"key1": "a"}, 10, "below")
-        assert "`key` must be either str or list" == str(excinfo.value)
+            threshold_model.check_bounds(["b", "a"], f"{include}-inf, 12)")
+        assert f"a must be between {include}-inf, 12.0)" == str(excinfo.value)
 
     def test_threshold_within_bounds(self, threshold_model):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", (9, 13), "within")
+            threshold_model.check_bounds("a", "[9, 13]")
             # single value, inclusive lower
-            threshold_model.check_bounds("a", (12.5, 13), "within")
+            threshold_model.check_bounds("a", "[12.5, 13]")
             # single value, inclusive upper
-            threshold_model.check_bounds("a", (9, 12.5), "within")
+            threshold_model.check_bounds("a", "[9, 12.5]")
             # multiple value
-            threshold_model.check_bounds(["a", "b"], (9, 13), "within")
+            threshold_model.check_bounds(["a", "b"], "[9, 13]")
             # multiple value, inclusive lower
-            threshold_model.check_bounds(["a", "b"], (10, 13), "within")
+            threshold_model.check_bounds(["a", "b"], "[10, 13]")
             # multiple value, inclusive upper
-            threshold_model.check_bounds(["a", "b"], (9, 12.5), "within")
+            threshold_model.check_bounds(["a", "b"], "[9, 12.5]")
             # multiple value, inclusive both
-            threshold_model.check_bounds(["a", "b"], (10, 12.5), "within")
+            threshold_model.check_bounds(["a", "b"], "[10, 12.5]")
             # multiple value, inclusive both
-            threshold_model.check_bounds(["a", "b", "d"], (10, 13), "within")
+            threshold_model.check_bounds(["a", "b", "d"], "[10, 13]")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail lower
-            threshold_model.check_bounds("a", (13, 14), "within")
-        assert "a must be between [13, 14]" == str(excinfo.value)
+            threshold_model.check_bounds("a", "[13, 14]")
+        assert "a must be between [13.0, 14.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail upper
-            threshold_model.check_bounds("a", (9, 11), "within")
-        assert "a must be between [9, 11]" == str(excinfo.value)
+            threshold_model.check_bounds("a", "[9, 11]")
+        assert "a must be between [9.0, 11.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail lower
-            threshold_model.check_bounds(["a", "b"], (11, 13), "within")
-        assert "b must be between [11, 13]" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[11, 13]")
+        assert "b must be between [11.0, 13.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail upper
-            threshold_model.check_bounds(["a", "b"], (9, 11), "within")
-        assert "a must be between [9, 11]" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[9, 11]")
+        assert "a must be between [9.0, 11.0]" == str(excinfo.value)
 
     def test_threshold_within_bounds_exclusive_lower(self, threshold_model):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", (9, 13), "within", include="upper")
+            threshold_model.check_bounds("a", "(9, 13]")
             # single value, inclusive upper
-            threshold_model.check_bounds("a", (9, 12.5), "within", include="upper")
+            threshold_model.check_bounds("a", "(9, 12.5]")
             # multiple value
-            threshold_model.check_bounds(["a", "b"], (9, 13), "within", include="upper")
+            threshold_model.check_bounds(["a", "b"], "(9, 13]")
             # multiple value, inclusive upper
-            threshold_model.check_bounds(
-                ["a", "b"], (9, 12.5), "within", include="upper"
-            )
+            threshold_model.check_bounds(["a", "b"], "(9, 12.5]")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive lower, fail
-            threshold_model.check_bounds("a", (12.5, 13), "within", include="upper")
-        assert "a must be between (12.5, 13]" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(12.5, 13]")
+        assert "a must be between (12.5, 13.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive lower, fail
-            threshold_model.check_bounds("d", (10, 13), "within", include="upper")
-        assert "All elements of d must be between (10, 13]" == str(excinfo.value)
+            threshold_model.check_bounds("d", "(10, 13]")
+        assert "All elements of d must be between (10.0, 13.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, above bounds, fail
-            threshold_model.check_bounds("a", (9, 11), "within", include="upper")
-        assert "a must be between (9, 11]" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(9, 11]")
+        assert "a must be between (9.0, 11.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, below bounds, fail
-            threshold_model.check_bounds("a", (13, 14), "within", include="upper")
-        assert "a must be between (13, 14]" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(13, 14]")
+        assert "a must be between (13.0, 14.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive lower, fail
-            threshold_model.check_bounds(
-                ["a", "b"], (10, 13), "within", include="upper"
-            )
-        assert "b must be between (10, 13]" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(10, 13]")
+        assert "b must be between (10.0, 13.0]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive upper, fail
-            threshold_model.check_bounds(
-                ["a", "b"], (11, 12.5), "within", include="upper"
-            )
-        assert "b must be between (11, 12.5]" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(11, 12.5]")
+        assert "b must be between (11.0, 12.5]" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive both
-            threshold_model.check_bounds(
-                ["a", "b"], (10, 12.5), "within", include="upper"
-            )
-        assert "b must be between (10, 12.5]" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(10, 12.5]")
+        assert "b must be between (10.0, 12.5]" == str(excinfo.value)
 
     def test_threshold_within_bounds_exclusive_upper(self, threshold_model):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", (9, 13), "within", include="lower")
+            threshold_model.check_bounds("a", "[9, 13)")
             # single value, inclusive lower
-            threshold_model.check_bounds("a", (12.5, 13), "within", include="lower")
+            threshold_model.check_bounds("a", "[12.5, 13)")
             # multiple value
-            threshold_model.check_bounds(["a", "b"], (9, 13), "within", include="lower")
+            threshold_model.check_bounds(["a", "b"], "[9, 13)")
             # multiple value, inclusive lower
-            threshold_model.check_bounds(
-                ["a", "b"], (10, 13), "within", include="lower"
-            )
+            threshold_model.check_bounds(["a", "b"], "[10, 13)")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail lower
-            threshold_model.check_bounds("a", (13, 14), "within", include="lower")
-        assert "a must be between [13, 14)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "[13, 14)")
+        assert "a must be between [13.0, 14.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail upper
-            threshold_model.check_bounds("a", (9, 11), "within", include="lower")
-        assert "a must be between [9, 11)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "[9, 11)")
+        assert "a must be between [9.0, 11.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive upper, fail
-            threshold_model.check_bounds("a", (9, 12.5), "within", include="lower")
-        assert "a must be between [9, 12.5)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "[9, 12.5)")
+        assert "a must be between [9.0, 12.5)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive upper, fail
-            threshold_model.check_bounds("d", (9, 13), "within", include="lower")
-        assert "All elements of d must be between [9, 13)" == str(excinfo.value)
+            threshold_model.check_bounds("d", "[9, 13)")
+        assert "All elements of d must be between [9.0, 13.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail lower
-            threshold_model.check_bounds(
-                ["a", "b"], (11, 13), "within", include="lower"
-            )
-        assert "b must be between [11, 13)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[11, 13)")
+        assert "b must be between [11.0, 13.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail upper
-            threshold_model.check_bounds(["a", "b"], (9, 11), "within", include="lower")
-        assert "a must be between [9, 11)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[9, 11)")
+        assert "a must be between [9.0, 11.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive upper, fail
-            threshold_model.check_bounds(
-                ["a", "b"], (9, 12.5), "within", include="lower"
-            )
-        assert "a must be between [9, 12.5)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[9, 12.5)")
+        assert "a must be between [9.0, 12.5)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive both, fail
-            threshold_model.check_bounds(
-                ["a", "b"], (10, 12.5), "within", include="lower"
-            )
-        assert "a must be between [10, 12.5)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "[10, 12.5)")
+        assert "a must be between [10.0, 12.5)" == str(excinfo.value)
 
     def test_threshold_within_bounds_exclusive_both(self, threshold_model):
         with not_raises(ValueError):
             # single value
-            threshold_model.check_bounds("a", (9, 13), "within", include=None)
+            threshold_model.check_bounds("a", "(9, 13)")
             # multiple value
-            threshold_model.check_bounds(["a", "b"], (9, 13), "within", include=None)
+            threshold_model.check_bounds(["a", "b"], "(9, 13)")
             # multiple value
-            threshold_model.check_bounds(
-                ["a", "b", "d"], (9, 13.5), "within", include=None
-            )
+            threshold_model.check_bounds(["a", "b", "d"], "(9, 13.5)")
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail lower
-            threshold_model.check_bounds("a", (13, 14), "within", include=None)
-        assert "a must be between (13, 14)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(13, 14)")
+        assert "a must be between (13.0, 14.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, fail upper
-            threshold_model.check_bounds("a", (9, 11), "within", include=None)
-        assert "a must be between (9, 11)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(9, 11)")
+        assert "a must be between (9.0, 11.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive lower, fail
-            threshold_model.check_bounds("a", (12.5, 13), "within", include=None)
-        assert "a must be between (12.5, 13)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(12.5, 13)")
+        assert "a must be between (12.5, 13.0)" == str(excinfo.value)
         with pytest.raises(ValueError) as excinfo:
             # single value, inclusive upper, fail
-            threshold_model.check_bounds("a", (9, 12.5), "within", include=None)
-        assert "a must be between (9, 12.5)" == str(excinfo.value)
+            threshold_model.check_bounds("a", "(9, 12.5)")
+        assert "a must be between (9.0, 12.5)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail lower
-            threshold_model.check_bounds(["a", "b"], (11, 13), "within", include=None)
-        assert "b must be between (11, 13)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(11, 13)")
+        assert "b must be between (11.0, 13.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, fail upper
-            threshold_model.check_bounds(["a", "b"], (9, 11), "within", include=None)
-        assert "a must be between (9, 11)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(9, 11)")
+        assert "a must be between (9.0, 11.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive lower, fail
-            threshold_model.check_bounds(["a", "b"], (10, 13), "within", include=None)
-        assert "b must be between (10, 13)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(10, 13)")
+        assert "b must be between (10.0, 13.0)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive upper, fail
-            threshold_model.check_bounds(["a", "b"], (9, 12.5), "within", include=None)
-        assert "a must be between (9, 12.5)" == str(excinfo.value)
+            threshold_model.check_bounds(["a", "b"], "(9, 12.5)")
+        assert "a must be between (9.0, 12.5)" == str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             # multiple value, inclusive both, fail
-            threshold_model.check_bounds(["a", "b"], (10, 12.5), "within", include=None)
+            threshold_model.check_bounds(["a", "b"], "(10, 12.5)")
         # Implementation quirk: checks all lower bounds first and then upper
         # bound instead of checking both bounds following the key order
-        assert "b must be between (10, 12.5)" == str(excinfo.value)
-
-    def test_threshold_within_bounds_invalid_type(self, threshold_model):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds({"key1": "a"}, (10, 12), "within")
-        assert "`key` must be either str or list" == str(excinfo.value)
-
-    def test_threshold_invalid_method(self, threshold_model):
-        with pytest.raises(ValueError) as excinfo:
-            threshold_model.check_bounds("a", 12, "invalid_method")
-        assert "`method` must be one of" in str(excinfo.value)
-
-    def test_threshold_invalid_tuple_type(self, threshold_model):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds("a", (12, "a"), "within")
-        assert "When using tuple for `value`, it must be a tuple of float/int" == str(
-            excinfo.value
-        )
-
-    def test_threshold_invalid_tuple_length(self, threshold_model):
-        with pytest.raises(ValueError) as excinfo:
-            threshold_model.check_bounds("a", (1, 2, 3), "within")
-        assert "When using tuple for `value`, it must contain only 2 elements" == str(
-            excinfo.value
-        )
-
-    def test_threshold_invalid_value_type(self, threshold_model):
-        value = {1, 2}
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds("a", value, "within")
-        assert (
-            f"`value` must be a float/int or tuple, but you passed a {type(value).__name__}"
-            == str(excinfo.value)
-        )
-
-    def test_threshold_invalid_within_value_type(self, threshold_model):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds("a", 1, "within")
-        assert "`value` must be a tuple when `method` is 'within'" == str(excinfo.value)
-
-    @pytest.mark.parametrize("method", ["above", "below"])
-    def test_threshold_invalid_above_below_value_type(self, threshold_model, method):
-        with pytest.raises(TypeError) as excinfo:
-            threshold_model.check_bounds("a", (1, 2), method)
-        assert "`value` must be a float/int when `method` is 'above'/'below'" == str(
-            excinfo.value
-        )
+        assert "b must be between (10.0, 12.5)" == str(excinfo.value)
 
     def test_threshold_valid_choice(self, threshold_model):
         with not_raises(ValueError):

--- a/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
+++ b/tests/pipeline/nodes/model/csrnetv1/test_csrnet.py
@@ -69,4 +69,4 @@ class TestCsrnet:
     def test_invalid_config_value(self, csrnet_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=csrnet_bad_config_value)
-        assert "must be more than 0" in str(excinfo.value)
+        assert "must be between (0.0, inf]" in str(excinfo.value)

--- a/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
+++ b/tests/pipeline/nodes/model/hrnetv1/test_hrnet.py
@@ -124,4 +124,4 @@ class TestHrnet:
     def test_invalid_config_value(self, hrnet_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=hrnet_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -264,7 +264,7 @@ class TestJDE:
     def test_invalid_config_value(self, jde_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=jde_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)
 
     @mock.patch.object(WeightsDownloaderMixin, "_has_weights", return_value=True)
     def test_invalid_config_model_files(self, _, jde_config):

--- a/tests/pipeline/nodes/model/yolov4/test_yolo.py
+++ b/tests/pipeline/nodes/model/yolov4/test_yolo.py
@@ -100,7 +100,7 @@ class TestYolo:
     def test_invalid_config_value(self, yolo_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=yolo_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)
 
     @mock.patch.object(WeightsDownloaderMixin, "_has_weights", return_value=True)
     def test_invalid_config_model_files(self, _, yolo_config):

--- a/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
+++ b/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
@@ -100,4 +100,4 @@ class TestYolo:
     def test_invalid_config_value(self, yolo_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=yolo_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)

--- a/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
+++ b/tests/pipeline/nodes/model/yolov4_license_plate/test_yolov4_license_plate.py
@@ -88,4 +88,4 @@ class TestYOLOLicensePlate:
     def test_invalid_config_value(self, yolo_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=yolo_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)

--- a/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
+++ b/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
@@ -137,7 +137,7 @@ class TestYOLOX:
     def test_invalid_config_value(self, yolox_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=yolox_bad_config_value)
-        assert "_threshold must be between [0, 1]" in str(excinfo.value)
+        assert "_threshold must be between [0.0, 1.0]" in str(excinfo.value)
 
     @mock.patch.object(WeightsDownloaderMixin, "_has_weights", return_value=True)
     def test_invalid_config_model_files(self, _, yolox_config):


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/83

Changes:
- Uses a string to represent the interval of valid values.
- Checks formatting of the interval string using regex (see details below).

The interval string must match `^[\[\(]\s*[-+]?(inf|\d*\.?\d+)\s*,\s*[-+]?(inf|\d*\.?\d+)\s*[\]\)]$`:
- `^`: Start of line
- `[\[\(]`: Either `[` or `(`
- `\s*`: Any whitespace characters between 0 and unlimited times
- `[-+]?`: `-` or `+` between 0 and 1 time
- `(inf|\d*\.?\d+)`: Either `inf` or a decimal number where having a digit before the period is optional, e.g., `.9`. [Ref](https://stackoverflow.com/a/12117062) comment by Chandranshu
- `\s*`: Whitespace
- `,`: Separator
- `\s*`: Whitespace
- `[-+]?(inf|\d*\.?\d+)`: Optional `-` or `+` with either `inf` or a decimal number
- `\s*`: Whitespace
- `[\]\)]`: Either `]` or `)`
- `$`: End of line

Since we are trying to use a mathematical representation of the interval, I have opted to use `-inf` and `+inf` for correctness.