### PR TITLE
Feat: replace `detect_ids` with `detect`

### DIFF
--- a/docs/source/resources/01a_object_detection.rst
+++ b/docs/source/resources/01a_object_detection.rst
@@ -140,7 +140,7 @@ General Object Detection
 ------------------------
 
 | The tables below provide the associated indices for each class in object detectors.
-| To detect all classes, specify :code:`detect_ids: ["*"]` under the object detection node configuration in ``pipeline_config.yml``.
+| To detect all classes, specify :code:`detect: ["*"]` under the object detection node configuration in ``pipeline_config.yml``.
 
 +---------------+-----------------------------+----------------+-----------------------------+
 |               | ID                          |                | ID                          |

--- a/docs/source/tutorials/02_duck_confit.rst
+++ b/docs/source/tutorials/02_duck_confit.rst
@@ -50,7 +50,7 @@ To perform object detection on the ``cat_and_computer.mp4`` file, edit the
    - input.visual:
        source: cat_and_computer.mp4
    - model.yolo:
-       detect_ids: ["cup", "cat", "laptop", "keyboard", "mouse"]
+       detect: ["cup", "cat", "laptop", "keyboard", "mouse"]
    - draw.bbox:
        show_labels: True    # configure draw.bbox to display object labels
    - output.screen
@@ -79,7 +79,7 @@ The 30-second video will auto-close at the end, or you can press :greenbox:`q` t
 
        The YOLO model can detect 80 different :ref:`object classes
        <general-object-detection-ids>`. By default, it only detects the ``"person"`` class. Use
-       ``detect_ids: ["*"]`` in the ``pipeline_config.yml`` to configure the model to detect all 80
+       ``detect: ["*"]`` in the ``pipeline_config.yml`` to configure the model to detect all 80
        classes.
 
 
@@ -101,7 +101,7 @@ Edit ``pipeline_config.yml`` as shown below:
    - input.visual:
        source: cat_and_computer.mp4
    - model.yolo:
-       detect_ids: ["cup", "cat", "laptop", "keyboard", "mouse"]
+       detect: ["cup", "cat", "laptop", "keyboard", "mouse"]
    - draw.bbox:
        show_labels: True
    - dabble.fps                           # add new dabble node

--- a/docs/source/tutorials/03_custom_nodes.rst
+++ b/docs/source/tutorials/03_custom_nodes.rst
@@ -292,7 +292,7 @@ implement our custom node function.
       - input.visual:
           source: cat_and_computer.mp4
       - model.yolo:
-          detect_ids: ["cup", "cat", "laptop", "keyboard", "mouse"]
+          detect: ["cup", "cat", "laptop", "keyboard", "mouse"]
       - draw.bbox:
           show_labels: True
       - custom_nodes.draw.score

--- a/docs/source/tutorials/04_peaking_duck.rst
+++ b/docs/source/tutorials/04_peaking_duck.rst
@@ -296,7 +296,7 @@ Edit ``pipeline_config.yml`` as follows:
       - input.visual:
           source: highway_cars.mp4
       - model.yolo:
-          detect_ids: ["car"]
+          detect: ["car"]
           score_threshold: 0.3
       - dabble.bbox_count
       - dabble.fps
@@ -362,7 +362,7 @@ Create the following ``pipeline_config.yml``:
       - input.visual:
           source: people_walking.mp4
       - model.yolo:
-          detect_ids: ["person"]
+          detect: ["person"]
       - dabble.tracking
       - dabble.statistics:
           maximum: obj_attrs["ids"]
@@ -455,7 +455,7 @@ Change ``pipeline_config.yml`` to the following:
       - input.visual:
           source: people_walking.mp4
       - model.yolo:
-          detect_ids: ["person"]
+          detect: ["person"]
       - dabble.bbox_to_btm_midpoint
       - dabble.zone_count:
           resolution: [720, 480]

--- a/docs/source/tutorials/05_calling_peekingduck_in_python.rst
+++ b/docs/source/tutorials/05_calling_peekingduck_in_python.rst
@@ -148,7 +148,7 @@ Copy over the following code to ``demo_debug.py``:
           debug_node = debug.Node(pkd_base_dir=Path.cwd() / "src" / "custom_nodes")
       
           visual_node = visual.Node(source=str(Path.cwd() / "cat_and_computer.mp4"))
-          yolo_node = yolo.Node(detect_ids=["cup", "cat", "laptop", "keyboard", "mouse"])
+          yolo_node = yolo.Node(detect=["cup", "cat", "laptop", "keyboard", "mouse"])
           bbox_node = bbox.Node(show_labels=True)
       
           fps_node = fps.Node()
@@ -211,7 +211,7 @@ You should see the following output in your terminal:
    2022-02-24 16:33:06 peekingduck.pipeline.nodes.input.visual  INFO:  Config for node input.visual is updated to: 'source': ~user/pkd_project/cat_and_computer.mp4 
    2022-02-24 16:33:06 peekingduck.pipeline.nodes.input.visual  INFO:  Video/Image size: 720 by 480 
    2022-02-24 16:33:06 peekingduck.pipeline.nodes.input.visual  INFO:  Filepath used: ~user/pkd_project/cat_and_computer.mp4 
-   2022-02-24 16:33:06 peekingduck.pipeline.nodes.model.yolo  INFO:  Config for node model.yolo is updated to: 'detect_ids': [41, 15, 63, 66, 64] 
+   2022-02-24 16:33:06 peekingduck.pipeline.nodes.model.yolo  INFO:  Config for node model.yolo is updated to: 'detect': [41, 15, 63, 66, 64] 
    2022-02-24 16:33:06 peekingduck.pipeline.nodes.model.yolov4.yolo_files.detector  INFO:  Yolo model loaded with following configs: 
        Model type: v4tiny, 
        Input resolution: 416, 

--- a/docs/source/use_cases/face_mask_detection.rst
+++ b/docs/source/use_cases/face_mask_detection.rst
@@ -77,7 +77,7 @@ Some common node behaviors that you might want to adjust are:
 
 * ``model_type``: This specifies the variant of YOLOv4 to be used. By default, the `v4tiny` model
   is used, but for better accuracy, you may want to try the `v4` model.
-* ``detect_ids``: This specifies the class to be detected where no_mask = 0 and mask = 1. By default,
+* ``detect``: This specifies the class to be detected where no_mask = 0 and mask = 1. By default,
   the model detects faces with and without face masks (default = [0, 1]).
 * ``score_threshold``: This specifies the threshold value. Bounding boxes with confidence score
   lower than the threshold are discarded. You may want to lower the threshold value to increase the

--- a/docs/source/use_cases/object_counting_over_time.rst
+++ b/docs/source/use_cases/object_counting_over_time.rst
@@ -105,7 +105,7 @@ These are the nodes used in the earlier demo (also in |pipeline_config|_):
    - input.visual:
        source: <path/to/video with cars>
    - model.efficientdet:
-       detect_ids: ["car"]
+       detect: ["car"]
    - dabble.tracking:
        tracking_type: "iou"
    - dabble.statistics:
@@ -151,7 +151,7 @@ For :mod:`model.efficientdet`:
 
 * ``model_type``: ``0``, ``1``, ``2``, ``3``, or ``4``. The larger the number, the higher the
   accuracy, at the cost of inference speed.
-* ``detect_ids``: Object class IDs to be detected. 
+* ``detect``: Object class IDs to be detected. 
   Refer to :ref:`Object Detection IDs table <general-object-detection-ids>` for the class IDs for
   each model.
 

--- a/docs/source/use_cases/object_counting_present.rst
+++ b/docs/source/use_cases/object_counting_present.rst
@@ -85,7 +85,7 @@ These are the nodes used in the earlier demo (also in |pipeline_config|_):
    - input.visual:
        source: 0
    - model.yolo:
-       detect_ids: ["person"]
+       detect: ["person"]
    - dabble.bbox_count
    - dabble.statistics:
        identity: count

--- a/docs/source/use_cases/zone_counting.rst
+++ b/docs/source/use_cases/zone_counting.rst
@@ -129,7 +129,7 @@ These are the nodes used in the earlier demo (also in |pipeline_config|_):
    - input.visual:
        source: 0
    - model.yolo:
-       detect_ids: ["person"]
+       detect: ["person"]
    - dabble.bbox_to_btm_midpoint
    - dabble.zone_count:
        resolution: [1280, 720] # Adjust this to your camera's input resolution

--- a/peekingduck/configs/model/efficientdet.yml
+++ b/peekingduck/configs/model/efficientdet.yml
@@ -33,5 +33,5 @@ model_nodes:
 
 model_format: tensorflow
 model_type: 0 # 0-4
-detect_ids: [0]
+detect: [0]
 score_threshold: 0.3

--- a/peekingduck/configs/model/yolo.yml
+++ b/peekingduck/configs/model/yolo.yml
@@ -20,6 +20,6 @@ model_nodes: { inputs: [x:0], outputs: [Identity:0] }
 
 model_format: tensorflow
 model_type: v4tiny # v4 or v4tiny
-detect_ids: [0]
+detect: [0]
 iou_threshold: 0.5
 score_threshold: 0.2

--- a/peekingduck/configs/model/yolo_face.yml
+++ b/peekingduck/configs/model/yolo_face.yml
@@ -18,6 +18,6 @@ max_total_size: 50
 
 model_format: tensorflow
 model_type: v4tiny # v4 or v4tiny
-detect_ids: [0, 1]
+detect: [0, 1]
 iou_threshold: 0.1
 score_threshold: 0.7

--- a/peekingduck/configs/model/yolox.yml
+++ b/peekingduck/configs/model/yolox.yml
@@ -36,7 +36,7 @@ num_classes: 80
 model_format: pytorch
 model_type: yolox-tiny # yolox-tiny, yolox-s, yolox-m, or yolox-l
 input_size: 416
-detect_ids: [0]
+detect: [0]
 iou_threshold: 0.45
 score_threshold: 0.25
 agnostic_nms: true

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -224,14 +224,18 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
                     if key in ["detect", "detect_ids"]:
                         # Deprecation notice for "detect_ids"
                         if key == "detect_ids":
-                            self.logger.warning(
+                            deprecate(
                                 "`detect_ids` is deprecated and will be removed in future. "
-                                "Please use `detect` instead."
+                                "Please use `detect` instead.",
+                                4,
                             )
 
-                        key, value = obj_det_change_class_name_to_id(
-                            node_name, key, value
-                        )
+                        # Only convert class names to id if model is not yolo_face,
+                        # since yolo_face has no class names
+                        if node_name != "model.yolo_face":
+                            key, value = obj_det_change_class_name_to_id(
+                                node_name, key, value
+                            )
                         key = "detect"  # replace "detect_ids" with new "detect"
 
                     dict_orig[key] = value

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -84,7 +84,9 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
         """Loads a list of nodes from pipeline_path.yml"""
 
         # dotw 2022-03-17: Temporary helper methods
-        def deprecation_warning(name: str, config: Union[str, Dict[str, Any]]) -> None:
+        def input_node_deprecation_warning(
+            name: str, config: Union[str, Dict[str, Any]]
+        ) -> None:
             deprecate(
                 f"`{name}` deprecated and will be removed in the future. "
                 "Please use `input.visual` instead.",
@@ -111,7 +113,7 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
         for node in nodes:
             if isinstance(node, str):
                 if node in ["input.live", "input.recorded"]:
-                    deprecation_warning(node, "input.visual")
+                    input_node_deprecation_warning(node, "input.visual")
                     if node == "input.live":
                         node = {"input.visual": {"source": 0}}
                     else:
@@ -123,13 +125,13 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
                     if "input_source" in node_config:
                         node_config["source"] = node_config.pop("input_source")
                     node["input.visual"] = node_config
-                    deprecation_warning("input.live", node_config)
+                    input_node_deprecation_warning("input.live", node_config)
                 if "input.recorded" in node:
                     node_config = node.pop("input.recorded")
                     if "input_dir" in node_config:
                         node_config["source"] = node_config.pop("input_dir")
                     node["input.visual"] = node_config
-                    deprecation_warning("input.recorded", node_config)
+                    input_node_deprecation_warning("input.recorded", node_config)
             upgraded_nodes.append(node)
 
         self.logger.info("Successfully loaded pipeline file.")
@@ -212,15 +214,25 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
                     dict_orig.get(key, {}), value, node_name  # type: ignore
                 )
             else:
-                if key not in dict_orig:
+                # Replace "detect_ids" with "detect" in code below
+                if key not in dict_orig and key != "detect_ids":
                     self.logger.warning(
                         f"Config for node {node_name} does not have the key: {key}"
                     )
                 else:
-                    if key == "detect_ids":
+                    # Support "detect: ['person']" instead of "detect_ids: ['person']"
+                    if key in ["detect", "detect_ids"]:
+                        # Deprecation notice for "detect_ids"
+                        if key == "detect_ids":
+                            self.logger.warning(
+                                "`detect_ids` is deprecated and will be removed in future. "
+                                "Please use `detect` instead."
+                            )
+
                         key, value = obj_det_change_class_name_to_id(
                             node_name, key, value
                         )
+                        key = "detect"  # replace "detect_ids" with new "detect"
 
                     dict_orig[key] = value
                     self.logger.info(

--- a/peekingduck/pipeline/nodes/abstract_node.py
+++ b/peekingduck/pipeline/nodes/abstract_node.py
@@ -66,11 +66,13 @@ class AbstractNode(metaclass=ABCMeta):
 
         # For object detection nodes, convert class names to class ids, if any
         if self.node_name in ["model.yolo", "model.efficientdet", "model.yolox"]:
-            current_ids = self.config["detect_ids"]
+            key = "detect" if hasattr(self, "detect") else "detect_ids"
+            current_ids = self.config[key]
             _, updated_ids = obj_det_change_class_name_to_id(
-                self.node_name, "detect_ids", current_ids
+                self.node_name, key, current_ids
             )
-            self.config["detect_ids"] = updated_ids
+            # replace "detect_ids" with new "detect"
+            self.config["detect"] = updated_ids
 
     @classmethod
     def __subclasshook__(cls: Any, subclass: Any) -> bool:

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -53,8 +53,8 @@ class Node(AbstractNode):
         score_threshold (:obj:`float`): **[0, 1], default = 0.3**.
             Bounding boxes with confidence score below the threshold will be
             discarded.
-        detect_ids (:obj:`List[int]`): **default = [0]**. |br|
-            List of object class IDs to be detected. To detect all classes,
+        detect (:obj:`List[int]`): **default = [0]**. |br|
+            List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
             Change the parent directory where weights will be stored by

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -53,7 +53,7 @@ class Node(AbstractNode):
         score_threshold (:obj:`float`): **[0, 1], default = 0.3**.
             Bounding boxes with confidence score below the threshold will be
             discarded.
-        detect (:obj:`List[int]`): **default = [0]**. |br|
+        detect (:obj:`List[Union[int, string]]`): **default = [0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet_d04/efficientdet_model.py
@@ -47,7 +47,7 @@ class EfficientDetModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
             val["id"] - 1: val["name"]
             for val in json.loads(classes_path.read_text()).values()
         }
-        self.detect_ids = config["detect_ids"]
+        self.detect_ids = config["detect"]  # change "detect_ids" to "detect"
         self.detector = Detector(
             model_dir,
             class_names,

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):
             replacing ``null`` with an absolute path to the desired directory.
         num_classes (:obj:`int`): **default = 80**. |br|
             Maximum number of objects to be detected.
-        detect (:obj:`List`): **default = [0]**. |br|
+        detect (:obj:`List[Union[int, string]]`): **default = [0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         max_output_size_per_class (:obj:`int`): **default = 50**. |br|

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -48,8 +48,8 @@ class Node(AbstractNode):
             replacing ``null`` with an absolute path to the desired directory.
         num_classes (:obj:`int`): **default = 80**. |br|
             Maximum number of objects to be detected.
-        detect_ids (:obj:`List`): **default = [0]**. |br|
-            List of object class IDs to be detected. To detect all classes,
+        detect (:obj:`List`): **default = [0]**. |br|
+            List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         max_output_size_per_class (:obj:`int`): **default = 50**. |br|
             Maximum number of detected instances for each class in an image.

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
             Change the parent directory where weights will be stored by
             replacing ``null`` with an absolute path to the desired directory.
-        detect (:obj:`List`): **default = [0, 1]**. |br|
+        detect (:obj:`List[int]`): **default = [0, 1]**. |br|
             List of object class IDs to be detected where `no_mask` is ``0``
             and `mask` is ``1``.
         max_output_size_per_class (:obj:`int`): **default = 50**. |br|

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
             Change the parent directory where weights will be stored by
             replacing ``null`` with an absolute path to the desired directory.
-        detect_ids (:obj:`List`): **default = [0, 1]**. |br|
+        detect (:obj:`List`): **default = [0, 1]**. |br|
             List of object class IDs to be detected where `no_mask` is ``0``
             and `mask` is ``1``.
         max_output_size_per_class (:obj:`int`): **default = 50**. |br|

--- a/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4/yolo_model.py
@@ -39,7 +39,7 @@ class YOLOModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         with open(model_dir / self.weights["classes_file"]) as infile:
             class_names = [line.strip() for line in infile.readlines()]
 
-        self.detect_ids = config["detect_ids"]
+        self.detect_ids = config["detect"]  # change "detect_ids" to "detect"
         self.detector = Detector(
             model_dir,
             class_names,

--- a/peekingduck/pipeline/nodes/model/yolov4_face/yolo_face_model.py
+++ b/peekingduck/pipeline/nodes/model/yolov4_face/yolo_face_model.py
@@ -41,7 +41,7 @@ class YOLOFaceModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         with open(model_dir / self.weights["classes_file"]) as infile:
             class_names = [line.strip() for line in infile.readlines()]
 
-        self.detect_ids = config["detect_ids"]
+        self.detect_ids = config["detect"]  # change "detect_ids" to "detect"
         self.detector = Detector(
             model_dir,
             class_names,

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -50,7 +50,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             replacing ``null`` with an absolute path to the desired directory.
         input_size (:obj:`int`): **default=416**. |br|
             Input image resolution of the YOLOX model.
-        detect (:obj:`List[int]`): **default=[0]**. |br|
+        detect (:obj:`List[Union[int, string]]`): **default=[0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         iou_threshold (:obj:`float`): **[0, 1], default = 0.45**. |br|

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -50,8 +50,8 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             replacing ``null`` with an absolute path to the desired directory.
         input_size (:obj:`int`): **default=416**. |br|
             Input image resolution of the YOLOX model.
-        detect_ids (:obj:`List[int]`): **default=[0]**. |br|
-            List of object category IDs to be detected. To detect all classes,
+        detect (:obj:`List[int]`): **default=[0]**. |br|
+            List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         iou_threshold (:obj:`float`): **[0, 1], default = 0.45**. |br|
             Overlapping bounding boxes with Intersection over Union (IoU) above
@@ -87,7 +87,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         objects.
 
         The classes of objects to be detected can be specified through the
-        `detect_ids` configuration option.
+        `detect` configuration option.
 
         Args:
             inputs (Dict): Inputs dictionary with the key `img`.

--- a/peekingduck/pipeline/nodes/model/yoloxv1/yolox_model.py
+++ b/peekingduck/pipeline/nodes/model/yoloxv1/yolox_model.py
@@ -53,7 +53,7 @@ class YOLOXModel(ThresholdCheckerMixin, WeightsDownloaderMixin):
         with open(model_dir / self.weights["classes_file"]) as infile:
             class_names = [line.strip() for line in infile.readlines()]
 
-        self.detect_ids = self.config["detect_ids"]
+        self.detect_ids = self.config["detect"]  # change "detect_ids" to "detect"
         self.detector = Detector(
             model_dir,
             class_names,

--- a/peekingduck/utils/create_node_helper.py
+++ b/peekingduck/utils/create_node_helper.py
@@ -179,25 +179,25 @@ def obj_det_load_class_id_mapping(node_name: str) -> Dict[str, int]:
 def obj_det_change_class_name_to_id(
     node_name: str, key: str, value: List[Any]
 ) -> Tuple[str, List[int]]:
-    """Process object detection model node's detect_ids key and check for
+    """Process object detection model node's detect key and check for
     any class names to be converted to object IDs.
     E.g. person to 0, car to 2
 
     Args:
         node_name (str): to determine which object detection model is being used
                          because different models can use different object IDs.
-        key (str): expected to be "detect_ids"; error otherwise.
+        key (str): expected to be "detect"; error otherwise.
         value (List[Any]): list of class names or object IDs for detection.
                            If object IDs, do nothing.
                            If class names, convert to object IDs.
 
     Returns:
-        Tuple[str, List[int]]: "detect_ids", list of sorted object IDs.
+        Tuple[str, List[int]]: "detect", list of sorted object IDs.
     """
     class_id_map = obj_det_load_class_id_mapping(node_name)
 
     if not value:
-        logger.warning("detect_ids list is empty, defaulting to detect person")
+        logger.warning("detect list is empty, defaulting to detect person")
         value = ["person"]
     elif value == ["*"]:
         logger.info("Detecting all object classes")

--- a/tests/loaders/test_declarative_loader.py
+++ b/tests/loaders/test_declarative_loader.py
@@ -263,51 +263,51 @@ class TestDeclarativeLoader:
     def test_obj_detection_label_to_id_all_int(self, declarativeloader):
         node_name = "model.yolo"
         orig_config = {
-            "detect_ids": [0],
+            "detect": [0],
         }
-        config_update = {"detect_ids": [0, 1, 2, 3, 5]}
-        ground_truth = {"detect_ids": [0, 1, 2, 3, 5]}
+        config_update = {"detect": [0, 1, 2, 3, 5]}
+        ground_truth = {"detect": [0, 1, 2, 3, 5]}
 
         test_config = declarativeloader._edit_config(
             orig_config, config_update, node_name
         )
-        assert test_config["detect_ids"] == ground_truth["detect_ids"]
+        assert test_config["detect"] == ground_truth["detect"]
 
     def test_obj_detection_label_to_id_all_text(self, declarativeloader):
         node_name = "model.yolo"
         orig_config = {
-            "detect_ids": [0],
+            "detect": [0],
         }
-        config_update = {"detect_ids": ["person", "car", "bus", "cell phone", "oven"]}
-        ground_truth = {"detect_ids": [0, 2, 5, 67, 69]}
+        config_update = {"detect": ["person", "car", "bus", "cell phone", "oven"]}
+        ground_truth = {"detect": [0, 2, 5, 67, 69]}
 
         test_config = declarativeloader._edit_config(
             orig_config, config_update, node_name
         )
-        assert test_config["detect_ids"] == ground_truth["detect_ids"]
+        assert test_config["detect"] == ground_truth["detect"]
 
     def test_obj_detection_label_to_id_mix_int_and_text(self, declarativeloader):
         node_name = "model.yolo"
         orig_config = {
-            "detect_ids": [0],
+            "detect": [0],
         }
-        config_update = {"detect_ids": [4, "bicycle", 10, "laptop", "teddy bear"]}
-        ground_truth = {"detect_ids": [1, 4, 10, 63, 77]}
+        config_update = {"detect": [4, "bicycle", 10, "laptop", "teddy bear"]}
+        ground_truth = {"detect": [1, 4, 10, 63, 77]}
 
         test_config = declarativeloader._edit_config(
             orig_config, config_update, node_name
         )
-        assert test_config["detect_ids"] == ground_truth["detect_ids"]
+        assert test_config["detect"] == ground_truth["detect"]
 
     def test_obj_detection_label_to_id_mix_int_and_text_duplicates(
         self, declarativeloader
     ):
         node_name = "model.yolo"
         orig_config = {
-            "detect_ids": [0],
+            "detect": [0],
         }
         config_update = {
-            "detect_ids": [
+            "detect": [
                 4,
                 "bicycle",
                 10,
@@ -318,20 +318,20 @@ class TestDeclarativeLoader:
                 10,
             ]
         }
-        ground_truth = {"detect_ids": [1, 4, 10, 63, 77]}
+        ground_truth = {"detect": [1, 4, 10, 63, 77]}
 
         test_config = declarativeloader._edit_config(
             orig_config, config_update, node_name
         )
-        assert test_config["detect_ids"] == ground_truth["detect_ids"]
+        assert test_config["detect"] == ground_truth["detect"]
 
     def test_obj_detection_label_to_id_mix_int_and_text_errors(self, declarativeloader):
         node_name = "model.yolo"
         orig_config = {
-            "detect_ids": [0],
+            "detect": [0],
         }
         config_update = {
-            "detect_ids": [
+            "detect": [
                 4,
                 "bicycle",
                 10,
@@ -344,12 +344,12 @@ class TestDeclarativeLoader:
                 "scary monster",
             ]
         }
-        ground_truth = {"detect_ids": [0, 1, 4, 10, 63, 77]}
+        ground_truth = {"detect": [0, 1, 4, 10, 63, 77]}
 
         test_config = declarativeloader._edit_config(
             orig_config, config_update, node_name
         )
-        assert test_config["detect_ids"] == ground_truth["detect_ids"]
+        assert test_config["detect"] == ground_truth["detect"]
 
     def test_get_pipeline(self, declarativeloader):
         with mock.patch(

--- a/tests/pipeline/nodes/model/yolov4/test_yolo.py
+++ b/tests/pipeline/nodes/model/yolov4/test_yolo.py
@@ -93,7 +93,7 @@ class TestYolo:
         assert yolo.model.detect_ids == [0]
 
     def test_invalid_config_detect_ids(self, yolo_config):
-        yolo_config["detect_ids"] = 1
+        yolo_config["detect"] = 1
         with pytest.raises(TypeError):
             _ = Node(config=yolo_config)
 

--- a/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
+++ b/tests/pipeline/nodes/model/yolov4_face/test_yolo_face.py
@@ -93,7 +93,7 @@ class TestYolo:
         assert yolo.model.detect_ids == [0, 1]
 
     def test_invalid_config_detect_ids(self, yolo_type):
-        yolo_type["detect_ids"] = 1
+        yolo_type["detect"] = 1
         with pytest.raises(TypeError):
             _ = Node(config=yolo_type)
 

--- a/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
+++ b/tests/pipeline/nodes/model/yoloxv1/test_yolox.py
@@ -130,7 +130,7 @@ class TestYOLOX:
         assert yolox.model.detect_ids == [0]
 
     def test_invalid_config_detect_ids(self, yolox_config):
-        yolox_config["detect_ids"] = 1
+        yolox_config["detect"] = 1
         with pytest.raises(TypeError):
             _ = Node(config=yolox_config)
 

--- a/tests/pipeline/nodes/test_node.py
+++ b/tests/pipeline/nodes/test_node.py
@@ -95,11 +95,11 @@ class TestNode:
     def test_node_obj_det_wildcard_efficientdet(self):
         """Test object detection wildcard for EfficientDet models"""
         node_name = "model.efficientdet"
-        key = "detect_ids"
+        key = "detect"
         val = ["*"]
         # fmt: off
         ground_truth = (
-            "detect_ids",
+            "detect",
             [
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16,
                 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 30, 31, 32, 33, 34, 35,
@@ -116,11 +116,11 @@ class TestNode:
     def test_config_loader_obj_det_wildcard_yolo(self):
         """Test object detection wildcard for Yolo models"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = ["*"]
         # fmt: off
         ground_truth = (
-            "detect_ids",
+            "detect",
             [
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -137,9 +137,9 @@ class TestNode:
     def test_config_loader_change_class_name_to_id_all_text(self):
         """Test translation on all text inputs"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = ["person", "car", "BUS", "CELL PHONE", "oven"]
-        ground_truth = ("detect_ids", [0, 2, 5, 67, 69])
+        ground_truth = ("detect", [0, 2, 5, 67, 69])
 
         test_res = obj_det_change_class_name_to_id(node_name, key, val)
         assert test_res == ground_truth
@@ -147,9 +147,9 @@ class TestNode:
     def test_config_loader_change_class_name_to_id_all_int(self):
         """Test translation on all integer inputs"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = [0, 1, 2, 3, 5]
-        ground_truth = ("detect_ids", [0, 1, 2, 3, 5])
+        ground_truth = ("detect", [0, 1, 2, 3, 5])
 
         test_res = obj_det_change_class_name_to_id(node_name, key, val)
         assert test_res == ground_truth
@@ -157,9 +157,9 @@ class TestNode:
     def test_config_loader_change_class_name_to_id_mix_int_text(self):
         """Test translation on heterogenous inputs"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = [4, "bicycle", 10, "LAPTOP", "teddy bear"]
-        ground_truth = ("detect_ids", [1, 4, 10, 63, 77])
+        ground_truth = ("detect", [1, 4, 10, 63, 77])
 
         test_res = obj_det_change_class_name_to_id(node_name, key, val)
         assert test_res == ground_truth
@@ -167,7 +167,7 @@ class TestNode:
     def test_config_loader_change_class_name_to_id_mix_int_text_duplicates(self):
         """Test translation with heterogenous inputs including duplicates"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = [
             4,
             "bicycle",
@@ -178,7 +178,7 @@ class TestNode:
             63,
             10,
         ]
-        ground_truth = ("detect_ids", [1, 4, 10, 63, 77])
+        ground_truth = ("detect", [1, 4, 10, 63, 77])
 
         test_res = obj_det_change_class_name_to_id(node_name, key, val)
         assert test_res == ground_truth
@@ -186,7 +186,7 @@ class TestNode:
     def test_config_loader_change_class_name_to_id_mix_int_text_errors(self):
         """Test translation with heterogenous inputs including errors"""
         node_name = "model.yolo"
-        key = "detect_ids"
+        key = "detect"
         val = [
             4,
             "bicycle",
@@ -199,7 +199,7 @@ class TestNode:
             "pokemon",
             "scary monster",
         ]
-        ground_truth = ("detect_ids", [0, 1, 4, 10, 63, 77])
+        ground_truth = ("detect", [0, 1, 4, 10, 63, 77])
 
         test_res = obj_det_change_class_name_to_id(node_name, key, val)
         assert test_res == ground_truth
@@ -209,14 +209,14 @@ class TestNode:
     # class names to class IDs correctly
     #
     def test_model_yolo_class_ids(self):
-        node_config = {"detect_ids": [1, 2, 3, 4, 5]}
+        node_config = {"detect": [1, 2, 3, 4, 5]}
         yolo_node = ObjDetNodeYolo(config=node_config)
         ground_truth = [1, 2, 3, 4, 5]
-        assert yolo_node.config["detect_ids"] == ground_truth
+        assert yolo_node.config["detect"] == ground_truth
 
     def test_model_yolo_class_names(self):
         node_config = {
-            "detect_ids": [
+            "detect": [
                 "fire hydrant",
                 "stop sign",
                 "parking meter",
@@ -226,11 +226,11 @@ class TestNode:
         }
         yolo_node = ObjDetNodeYolo(config=node_config)
         ground_truth = [10, 11, 12, 13, 14]
-        assert yolo_node.config["detect_ids"] == ground_truth
+        assert yolo_node.config["detect"] == ground_truth
 
     def test_model_yolo_class_names_mixed(self):
         node_config = {
-            "detect_ids": [
+            "detect": [
                 1,
                 2,
                 3,
@@ -245,17 +245,17 @@ class TestNode:
         }
         yolo_node = ObjDetNodeYolo(config=node_config)
         ground_truth = [1, 2, 3, 10, 11, 12, 13, 14, 20, 21]
-        assert yolo_node.config["detect_ids"] == ground_truth
+        assert yolo_node.config["detect"] == ground_truth
 
     def test_model_efficientdet_class_ids(self):
-        node_config = {"detect_ids": [1, 2, 3, 4, 5]}
+        node_config = {"detect": [1, 2, 3, 4, 5]}
         efficientdet_node = ObjDetNodeEfficientDet(config=node_config)
         ground_truth = [1, 2, 3, 4, 5]
-        assert efficientdet_node.config["detect_ids"] == ground_truth
+        assert efficientdet_node.config["detect"] == ground_truth
 
     def test_model_efficientdet_class_names(self):
         node_config = {
-            "detect_ids": [
+            "detect": [
                 "fire hydrant",
                 "stop sign",
                 "parking meter",
@@ -265,11 +265,11 @@ class TestNode:
         }
         efficientdet_node = ObjDetNodeEfficientDet(config=node_config)
         ground_truth = [10, 12, 13, 14, 15]
-        assert efficientdet_node.config["detect_ids"] == ground_truth
+        assert efficientdet_node.config["detect"] == ground_truth
 
     def test_model_efficientdet_class_names_mixed(self):
         node_config = {
-            "detect_ids": [
+            "detect": [
                 1,
                 2,
                 3,
@@ -284,4 +284,4 @@ class TestNode:
         }
         efficientdet_node = ObjDetNodeEfficientDet(config=node_config)
         ground_truth = [1, 2, 3, 10, 12, 13, 14, 15, 20, 21]
-        assert efficientdet_node.config["detect_ids"] == ground_truth
+        assert efficientdet_node.config["detect"] == ground_truth

--- a/tests/use_cases/systest_object_counting_over_time.yml
+++ b/tests/use_cases/systest_object_counting_over_time.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: tests/data/videos/humans_mot.mp4
 - model.efficientdet:
-    detect_ids: ["car"]
+    detect: ["car"]
 - dabble.tracking:
     tracking_type: iou
 - dabble.statistics:

--- a/tests/use_cases/systest_object_counting_present.yml
+++ b/tests/use_cases/systest_object_counting_present.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: "tests/data/images"
 - model.yolo:
-    detect_ids: ["person"]
+    detect: ["person"]
 - dabble.bbox_count
 - dabble.statistics:
     identity: count

--- a/tests/use_cases/systest_zone_counting.yml
+++ b/tests/use_cases/systest_zone_counting.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: "tests/data/images"
 - model.yolo:
-    detect_ids: ["person"]
+    detect: ["person"]
 - dabble.bbox_to_btm_midpoint
 - dabble.zone_count:
     resolution: [1280, 720]

--- a/use_cases/object_counting_over_time.yml
+++ b/use_cases/object_counting_over_time.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: <path/to/video with cars>
 - model.efficientdet:
-    detect_ids: ["car"]
+    detect: ["car"]
 - dabble.tracking:
     tracking_type: "iou"
 - dabble.statistics:

--- a/use_cases/object_counting_present.yml
+++ b/use_cases/object_counting_present.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: 0
 - model.yolo:
-    detect_ids: ["person"]
+    detect: ["person"]
 - dabble.bbox_count
 - dabble.statistics:
     identity: count

--- a/use_cases/zone_counting.yml
+++ b/use_cases/zone_counting.yml
@@ -2,7 +2,7 @@ nodes:
 - input.visual:
     source: 0
 - model.yolo:
-    detect_ids: ["person"]
+    detect: ["person"]
 - dabble.bbox_to_btm_midpoint
 - dabble.zone_count:
     resolution: [1280, 720]


### PR DESCRIPTION
Changes:
* Replace `detect_ids` with `detect` so as to be more user-friendly
    - Instead of `detect_ids: ["dog"]`, it is now `detect: ["dog"]`
    - Replace `detect_ids` in object detection models (efficientdet, yolo, yolox) configs
    - Update tests to use `detect` in place of `detect_ids`
    - Update docs and use cases yaml files
* Add deprecation warning notice for `detect_ids`.

Technotes:
* The changes stop at `peekingduck/pipeline/nodes/model` level, within the `__init__` of EfficientDet, Yolo and YoloX, relevant code shown below:
```
        self.detect_ids = config["detect"]  # change "detect_ids" to "detect"
```
* Internally, each object detection model still uses `self.detect_ids`.
* `detect` is used at the user-interface level.