### PR TITLE
fixed draw.legend background box size

### DIFF
--- a/peekingduck/pipeline/nodes/draw/utils/legend.py
+++ b/peekingduck/pipeline/nodes/draw/utils/legend.py
@@ -58,6 +58,7 @@ class Legend:
         self.frame = inputs["img"]
 
         self.legend_height = self._get_legend_height(inputs, items)
+        self.legend_width = self._get_legend_width(inputs, items)
         self._set_legend_variables(position)
 
         self._draw_legend_box(self.frame)
@@ -165,7 +166,7 @@ class Legend:
         cv2.rectangle(
             overlay,
             (self.legend_left_x, self.legend_starting_y),
-            (self.legend_left_x + 150, self.legend_starting_y + self.legend_height),
+            (self.legend_left_x + self.legend_width, self.legend_starting_y + self.legend_height),
             BLACK,
             FILLED,
         )
@@ -180,6 +181,51 @@ class Legend:
             # increase the number of items according to number of zones
             no_of_items += len(inputs["zone_count"])
         return 12 * no_of_items + 8 * (no_of_items - 1) + 20
+
+    @staticmethod
+    def _get_item_width(
+        item_name: str,
+        item_info: Union[int, float, str],
+    ) -> int:
+        """Get width of the text to be drawn. If item info is
+        of float type, it will be displayed in 2 decimal places.
+
+        Args:
+            item_name (str): name of the legend item
+            item_info: Union[int, float, str]: info contained by the legend item
+        """
+        if isinstance(item_info, (int, float, str)):
+            pass
+        else:
+            raise TypeError(
+                f"With the exception of the 'zone_count' data type, "
+                f"the draw.legend node only draws values that are of type 'int', 'float' or 'str' "
+                f"within the legend box. The value: {item_info} from the data type: {item_name} "
+                f"is of type: {type(item_info)} and is unable to be drawn."
+            )
+
+        if isinstance(item_info, float):
+            text = f"{item_name.upper()}: {item_info:.2f}"
+        else:
+            text = f"{item_name.upper()}: {str(item_info)}"
+
+        return cv2.getTextSize(
+            text,
+            FONT_HERSHEY_SIMPLEX,
+            SMALL_FONTSCALE,
+            THICK,
+        )[0][0]
+
+    @staticmethod
+    def _get_legend_width(inputs: Dict[str, Any], items: List[str]) -> int:
+        """Get width of legened box needed to contain all items drawn"""
+        max_width = 0
+        for item in items:
+            if item != "zone_count":
+                max_width = max(max_width, Legend._get_item_width(item, inputs[item]))
+
+        # give an additional buffer of 20
+        return max_width + 20
 
     def _set_legend_variables(self, position: str) -> None:
         assert self.legend_height != 0


### PR DESCRIPTION
Closes #654 

Change made: Precompute required background box width using [`cv2.getTextSize()`](https://docs.opencv.org/4.x/d6/d6e/group__imgproc__draw.html#ga3d2abfcb995fd2db908c8288199dba82)