### PR TITLE
Fixed OpenCV Lint Requirements

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -1,7 +1,7 @@
 click == 7.1.2
 colorama == 0.4.4
 numpy == 1.17.3
-opencv-contrib-python >= 4.5.2.54
+opencv-contrib-python >= 4.5.2.54, != 4.5.4.58, <= 4.5.5.64
 protobuf <= 3.20.1
 pyyaml >= 5.3
 requests == 2.24.0


### PR DESCRIPTION
Fixes #656

Changes made: changed `opencv-contrib-python >= 4.5.2.54` in `lint_requirements.txt` to `opencv-contrib-python >= 4.5.2.54, != 4.5.4.58, <= 4.5.5.64`