### PR TITLE
Fix: set is_initialized=True only when there is detection

### DIFF
--- a/peekingduck/pipeline/nodes/dabble/trackingv1/tracking_files/opencv_tracker.py
+++ b/peekingduck/pipeline/nodes/dabble/trackingv1/tracking_files/opencv_tracker.py
@@ -64,7 +64,6 @@ class OpenCVTracker:  # pylint: disable=too-few-public-methods
             for tlwh in tlwhs:
                 self._initialize_tracker(frame, tlwh)
             obj_track_ids = list(self.tracks.keys())
-            self.is_initialized = True
         self._update_tracker_bboxes(frame)
 
         return obj_track_ids
@@ -80,6 +79,7 @@ class OpenCVTracker:  # pylint: disable=too-few-public-methods
         tracker.init(frame, tuple(bbox))
         self.tracks[self.next_track_id] = Track(tracker, bbox)
         self.next_track_id += 1
+        self.is_initialized = True
 
     def _match_and_track(self, frame: np.ndarray, bboxes: np.ndarray) -> List[int]:
         """Matches detections to tracked bboxes, creates a new track if no

--- a/peekingduck/pipeline/nodes/dabble/trackingv1/tracking_files/opencv_tracker.py
+++ b/peekingduck/pipeline/nodes/dabble/trackingv1/tracking_files/opencv_tracker.py
@@ -14,7 +14,7 @@
 
 """Tracking-by-detection using OpenCV's MOSSE Tracker."""
 
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -96,14 +96,16 @@ class OpenCVTracker:  # pylint: disable=too-few-public-methods
             (List[int]): A list of track IDs for the detections in the current
                 frame.
         """
-        prev_tracked_bboxes = [track.bbox for _, track in self.tracks.items()]
-        matching_dict = {}
+        prev_tracks = [track.bbox for _, track in self.tracks.items()]
+        prev_tracked_bboxes = np.array(prev_tracks) if prev_tracks else np.empty((0, 4))
+        matching_dict: Dict[Tuple[float, ...], Optional[np.intp]] = {}
 
         for bbox in bboxes:
-            ious = iou_candidates(bbox, np.array(prev_tracked_bboxes))
-            matching_dict[tuple(bbox)] = (
-                ious.argmax() if max(ious) >= self.iou_threshold else None
-            )
+            ious = iou_candidates(bbox, prev_tracked_bboxes)
+            if len(ious) > 0 and max(ious) >= self.iou_threshold:
+                matching_dict[tuple(bbox)] = ious.argmax()
+            else:
+                matching_dict[tuple(bbox)] = None
 
         track_ids = []
         for bbox, matched_id in matching_dict.items():

--- a/tests/pipeline/nodes/dabble/test_tracking.py
+++ b/tests/pipeline/nodes/dabble/test_tracking.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 import platform
+from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
@@ -224,3 +224,14 @@ class TestTracking:
                 if i > 0:
                     assert outputs["obj_attrs"]["ids"] == prev_tags
                 prev_tags = outputs["obj_attrs"]["ids"]
+
+    def test_handle_empty_detections(
+        self, tracker, human_video_sequence_with_empty_frames
+    ):
+        # skip for mosse due to inconsistent results on Intel MacOS
+        if tracker.tracking_type == "mosse" and platform.system() == "Darwin":
+            pytest.skip()
+        _, detections = human_video_sequence_with_empty_frames
+        for inputs in detections:
+            outputs = tracker.run(inputs)
+            assert len(outputs["obj_attrs"]["ids"]) == len(inputs["bboxes"])

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -244,6 +244,16 @@ class TestFairMOT:
                 assert fairmot._frame_rate == pytest.approx(mot_metadata["frame_rate"])
                 prev_tags = output["obj_attrs"]["ids"]
 
+    def test_handle_empty_detections(
+        self, human_video_sequence_with_empty_frames, fairmot_config
+    ):
+        _, detections = human_video_sequence_with_empty_frames
+        fairmot = Node(fairmot_config)
+        for i, inputs in enumerate(detections):
+            output = fairmot.run(inputs)
+            if i > 1:
+                assert len(output["obj_attrs"]["ids"]) == len(inputs["bboxes"])
+
     def test_invalid_config_value(self, fairmot_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=fairmot_bad_config_value)

--- a/tests/pipeline/nodes/model/jdev1/test_jde.py
+++ b/tests/pipeline/nodes/model/jdev1/test_jde.py
@@ -261,6 +261,16 @@ class TestJDE:
                 assert jde._frame_rate == pytest.approx(mot_metadata["frame_rate"])
                 prev_tags = output["obj_attrs"]["ids"]
 
+    def test_handle_empty_detections(
+        self, human_video_sequence_with_empty_frames, jde_config
+    ):
+        _, detections = human_video_sequence_with_empty_frames
+        jde = Node(jde_config)
+        for i, inputs in enumerate(detections):
+            output = jde.run(inputs)
+            if i > 1:
+                assert len(output["obj_attrs"]["ids"]) == len(inputs["bboxes"])
+
     def test_invalid_config_value(self, jde_bad_config_value):
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=jde_bad_config_value)


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck/issues/661

Only set `is_initialized=True` when there is actual detection. This ensures that [`prev_tracked_bboxes`](https://github.com/aimakerspace/PeekingDuck/blob/main/peekingduck/pipeline/nodes/dabble/trackingv1/tracking_files/opencv_tracker.py#L99) will be non-empty when `_match_and_track()` is called.