### PR TITLE
Support full config path

### DIFF
--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [windows-2019, ubuntu-18.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,8 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [windows-2019, ubuntu-18.04]
-        os: [windows-2019]
+        os: [windows-2019, ubuntu-18.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge_ci.yml
+++ b/.github/workflows/pre_merge_ci.yml
@@ -6,7 +6,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-18.04]
+        # os: [windows-2019, ubuntu-18.04]
+        os: [windows-2019]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -21,7 +21,7 @@ import collections.abc
 import importlib
 import logging
 
-# import os
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -66,12 +66,12 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     ) -> None:
         self.logger = logging.getLogger(__name__)
 
-        # parent_path = str(pipeline_path.parent)
-        # if parent_path != Path.cwd() and parent_path[0] == "/":
-        #     self.logger.info(
-        #         f"{parent_path[0]}: changing working directory to {parent_path}"
-        #     )
-        #     os.chdir(parent_path)
+        parent_path = str(pipeline_path.parent)
+        if parent_path != Path.cwd() and parent_path[0] == "/":
+            self.logger.info(
+                f"{parent_path[0]}: changing working directory to {parent_path}"
+            )
+            os.chdir(parent_path)
 
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -20,7 +20,8 @@ import ast
 import collections.abc
 import importlib
 import logging
-import os
+
+# import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -66,8 +66,8 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     ) -> None:
         self.logger = logging.getLogger(__name__)
 
-        parent_path = str(pipeline_path.parent)
-        if parent_path != Path.cwd() and parent_path[0] == "/":
+        if pipeline_path.parent != Path.cwd() and pipeline_path.is_absolute():
+            parent_path = str(pipeline_path.parent)
             self.logger.info(
                 f"{parent_path[0]}: changing working directory to {parent_path}"
             )

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -20,6 +20,7 @@ import ast
 import collections.abc
 import importlib
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -63,6 +64,10 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
         custom_nodes_parent_subdir: str,
     ) -> None:
         self.logger = logging.getLogger(__name__)
+
+        if pipeline_path.parent != Path.cwd():
+            self.logger.info(f"changing working directory to {pipeline_path.parent}")
+            os.chdir(pipeline_path.parent)
 
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -65,9 +65,12 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     ) -> None:
         self.logger = logging.getLogger(__name__)
 
-        if pipeline_path.parent != Path.cwd():
-            self.logger.info(f"changing working directory to {pipeline_path.parent}")
-            os.chdir(pipeline_path.parent)
+        parent_path = str(pipeline_path.parent)
+        if parent_path != Path.cwd() and parent_path[0] == "/":
+            self.logger.info(
+                f"{parent_path[0]}: changing working directory to {parent_path}"
+            )
+            os.chdir(parent_path)
 
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -65,12 +65,12 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     ) -> None:
         self.logger = logging.getLogger(__name__)
 
-        parent_path = str(pipeline_path.parent)
-        if parent_path != Path.cwd() and parent_path[0] == "/":
-            self.logger.info(
-                f"{parent_path[0]}: changing working directory to {parent_path}"
-            )
-            os.chdir(parent_path)
+        # parent_path = str(pipeline_path.parent)
+        # if parent_path != Path.cwd() and parent_path[0] == "/":
+        #     self.logger.info(
+        #         f"{parent_path[0]}: changing working directory to {parent_path}"
+        #     )
+        #     os.chdir(parent_path)
 
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)

--- a/peekingduck/declarative_loader.py
+++ b/peekingduck/declarative_loader.py
@@ -66,15 +66,13 @@ class DeclarativeLoader:  # pylint: disable=too-few-public-methods
     ) -> None:
         self.logger = logging.getLogger(__name__)
 
-        if pipeline_path.parent != Path.cwd() and pipeline_path.is_absolute():
-            parent_path = str(pipeline_path.parent)
-            self.logger.info(
-                f"{parent_path[0]}: changing working directory to {parent_path}"
-            )
-            os.chdir(parent_path)
-
         self.pkd_base_dir = Path(__file__).resolve().parent
         self.config_loader = ConfigLoader(self.pkd_base_dir)
+
+        if pipeline_path.parent != Path.cwd() and pipeline_path.is_absolute():
+            parent_path = str(pipeline_path.parent)
+            self.logger.info(f"change working directory to {parent_path}")
+            os.chdir(parent_path)
 
         self.node_list = self._load_node_list(pipeline_path)
         self.config_updates_cli = ast.literal_eval(config_updates_cli)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -290,7 +290,6 @@ class TestCli:
         print(f"\ntmp_dir={tmp_dir}")
         unit_test_run_dir = Path(__file__).parents[3]
         print(f"unit_test_run_dir={unit_test_run_dir}")
-        test_config_path = tmp_dir / "test_config.yml"
         nodes = {
             "nodes": [
                 {
@@ -300,11 +299,13 @@ class TestCli:
                 }
             ]
         }
+        os.chdir(unit_test_run_dir)
+        # test_config_path = tmp_dir / "test_config.yml"
+        test_config_path = "test_config.yml"
         with open(test_config_path, "w") as outfile:
             yaml.dump(nodes, outfile, default_flow_style=False)
 
         # run unit test
-        os.chdir(unit_test_run_dir)
         cmd = [
             "python",
             "PeekingDuck",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -30,6 +30,7 @@ from click.testing import CliRunner
 from peekingduck import __version__
 from peekingduck.cli import cli
 from peekingduck.declarative_loader import PEEKINGDUCK_NODE_TYPES
+from tests.conftest import assert_msg_in_logs
 
 UNIQUE_SUFFIX = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
 CUSTOM_FOLDER_NAME = f"custom_nodes_{UNIQUE_SUFFIX}"
@@ -67,26 +68,6 @@ YML = dict(
 
 PKD_DIR = Path(__file__).resolve().parents[2] / "peekingduck"
 PKD_CONFIG_DIR = PKD_DIR / "configs"
-
-
-def assert_msg_in_logs(msg: str, msg_logs) -> bool:
-    """Helper method to test if given message is in a list of logged messages.
-
-    Args:
-        msg (str): message to check for
-        msg_logs (List[LogRecord]): log of messages
-
-    Returns:
-        bool: True if msg in msgs, otherwise False
-    """
-    print(f"msg_to_check={msg}")
-    print(f"type={type(msg_logs)}")
-    for i, log in enumerate(msg_logs):
-        the_msg = log.getMessage()
-        print(f"{i} {the_msg}")
-        if msg == the_msg:
-            return True
-    return False
 
 
 def available_nodes_msg(type_name=None):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -69,6 +69,26 @@ PKD_DIR = Path(__file__).resolve().parents[2] / "peekingduck"
 PKD_CONFIG_DIR = PKD_DIR / "configs"
 
 
+def assert_msg_in_logs(msg: str, msg_logs) -> bool:
+    """Helper method to test if given message is in a list of logged messages.
+
+    Args:
+        msg (str): message to check for
+        msg_logs (List[LogRecord]): log of messages
+
+    Returns:
+        bool: True if msg in msgs, otherwise False
+    """
+    print(f"msg_to_check={msg}")
+    print(f"type={type(msg_logs)}")
+    for i, log in enumerate(msg_logs):
+        the_msg = log.getMessage()
+        print(f"{i} {the_msg}")
+        if msg == the_msg:
+            return True
+    return False
+
+
 def available_nodes_msg(type_name=None):
     def len_enumerate(item):
         return int(math.log10(item[0] + 1)) + len(item[1])
@@ -198,9 +218,9 @@ class TestCli:
             result = CliRunner().invoke(cli, ["init"])
 
             assert result.exit_code == 0
-            assert (
-                captured.records[0].getMessage()
-                == f"Creating custom nodes folder in {cwd / 'src' / 'custom_nodes'}"
+            assert_msg_in_logs(
+                f"Creating custom nodes folder in {cwd / 'src' / 'custom_nodes'}",
+                captured.records,
             )
             assert (parent_dir / DEFAULT_NODE_DIR).exists()
             assert (parent_dir / DEFAULT_NODE_CONFIG_DIR).exists()
@@ -214,10 +234,11 @@ class TestCli:
             result = CliRunner().invoke(
                 cli, ["init", "--custom_folder_name", CUSTOM_FOLDER_NAME]
             )
+
             assert result.exit_code == 0
-            assert (
-                captured.records[0].getMessage()
-                == f"Creating custom nodes folder in {cwd / 'src' / CUSTOM_FOLDER_NAME}"
+            assert_msg_in_logs(
+                f"Creating custom nodes folder in {cwd / 'src' / CUSTOM_FOLDER_NAME}",
+                captured.records,
             )
             assert (parent_dir / CUSTOM_NODE_DIR).exists()
             assert (parent_dir / CUSTOM_NODE_CONFIG_DIR).exists()
@@ -229,11 +250,11 @@ class TestCli:
         setup()
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
             result = CliRunner().invoke(cli, ["run"])
-            assert (
-                captured.records[0].getMessage() == "Successfully loaded pipeline file."
-            )
-            assert captured.records[1].getMessage() == init_msg(PKD_NODE)
-            assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
+
+            assert_msg_in_logs("Successfully loaded pipeline file.", captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE), captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE_2), captured.records)
+
             assert result.exit_code == 0
 
     def test_run_custom_path(self):
@@ -242,11 +263,10 @@ class TestCli:
             result = CliRunner().invoke(
                 cli, ["run", "--config_path", CUSTOM_PIPELINE_PATH]
             )
-            assert (
-                captured.records[0].getMessage() == "Successfully loaded pipeline file."
-            )
-            assert captured.records[1].getMessage() == init_msg(PKD_NODE)
-            assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
+
+            assert_msg_in_logs("Successfully loaded pipeline file.", captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE), captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE_2), captured.records)
             assert result.exit_code == 0
 
     def test_run_custom_config(self):
@@ -260,15 +280,14 @@ class TestCli:
             result = CliRunner().invoke(
                 cli, ["run", "--node_config", config_update_cli]
             )
-            assert (
-                captured.records[0].getMessage() == "Successfully loaded pipeline file."
+
+            assert_msg_in_logs("Successfully loaded pipeline file.", captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE), captured.records)
+            assert_msg_in_logs(
+                f"Config for node {node_name} is updated to: {config_update_value}",
+                captured.records,
             )
-            assert captured.records[1].getMessage() == init_msg(PKD_NODE)
-            assert (
-                captured.records[2].getMessage()
-                == f"Config for node {node_name} is updated to: {config_update_value}"
-            )
-            assert captured.records[3].getMessage() == init_msg(PKD_NODE_2)
+            assert_msg_in_logs(init_msg(PKD_NODE_2), captured.records)
             assert result.exit_code == 0
 
     def test_nodes_all(self):
@@ -288,15 +307,20 @@ class TestCli:
         # setup unit test env
         tmp_dir = Path.cwd()
         print(f"\ntmp_dir={tmp_dir}")
+        unit_test_run_dir = Path(__file__).parents[3]
+        print(f"unit_test_run_dir={unit_test_run_dir}")
         test_config_path = tmp_dir / "test_config.yml"
         nodes = {
-            "nodes": [{"input.visual": {"source": "PeekingDuck/tests/data/images"}}]
+            "nodes": [
+                {
+                    "input.visual": {
+                        "source": f"{unit_test_run_dir}/PeekingDuck/tests/data/images"
+                    }
+                }
+            ]
         }
         with open(test_config_path, "w") as outfile:
             yaml.dump(nodes, outfile, default_flow_style=False)
-
-        unit_test_run_dir = Path(__file__).parents[3]
-        print(f"unit_test_run_dir={unit_test_run_dir}")
 
         # run unit test
         os.chdir(unit_test_run_dir)
@@ -321,12 +345,9 @@ class TestCli:
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
             n = 50  # run test for 50 iterations
             result = CliRunner().invoke(cli, ["run", "--num_iter", n])
-            assert (
-                captured.records[0].getMessage() == "Successfully loaded pipeline file."
-            )
-            assert captured.records[1].getMessage() == init_msg(PKD_NODE)
-            assert captured.records[2].getMessage() == init_msg(PKD_NODE_2)
-            assert (
-                captured.records[3].getMessage() == f"Run pipeline for {n} iterations"
-            )
+
+            assert_msg_in_logs("Successfully loaded pipeline file.", captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE), captured.records)
+            assert_msg_in_logs(init_msg(PKD_NODE_2), captured.records)
+            assert_msg_in_logs(f"Run pipeline for {n} iterations", captured.records)
             assert result.exit_code == 0

--- a/tests/cli/test_cli_create_node.py
+++ b/tests/cli/test_cli_create_node.py
@@ -21,6 +21,7 @@ import yaml
 from click.testing import CliRunner
 
 from peekingduck.cli import cli
+from tests.conftest import assert_msg_in_logs
 
 DEFAULT_NODES = ["input.visual", "model.yolo", "draw.bbox", "output.screen"]
 GOOD_SUBDIR = "custom_nodes"
@@ -451,27 +452,24 @@ class TestCliCreateNode:
             yaml.dump(data, outfile)
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
             CliRunner().invoke(cli, ["create-node", "--config_path", pipeline_file])
-            offset = 2  # First 2 message is about info about loading config
-            counter = 0
             for node_string in bad_paths:
-                assert (
+                assert_msg_in_logs(
                     f"{node_string} contains invalid formatting: 'Path cannot be "
-                    "absolute!'. Skipping..."
-                ) == captured.records[offset + counter].getMessage()
-                counter += 1
+                    "absolute!'. Skipping...",
+                    captured.records,
+                )
             for node_string in bad_types:
                 # Invalid type error message begins with a 'user_input' so we
                 # just check for the presence of the double single quote
-                assert (
-                    f"{node_string} contains invalid formatting: ''"
-                ) in captured.records[offset + counter].getMessage()
-                counter += 1
+                assert_msg_in_logs(
+                    f"{node_string} contains invalid formatting: ''", captured.records
+                )
             for node_string in bad_names:
-                assert (
+                assert_msg_in_logs(
                     f"{node_string} contains invalid formatting: 'Invalid node "
-                    "name!'. Skipping..."
-                ) == captured.records[offset + counter].getMessage()
-                counter += 1
+                    "name!'. Skipping...",
+                    captured.records,
+                )
 
     def test_create_nodes_from_config_success(self, cwd):
         """The custom nodes declared in the pipeline file only contains poor
@@ -499,11 +497,12 @@ class TestCliCreateNode:
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
             CliRunner().invoke(cli, ["create-node", "--config_path", pipeline_file])
             # First 2 message is about info about loading config
-            assert (
+            assert_msg_in_logs(
                 f"Creating files for {node_string}:\n\t"
                 f"Config file: {created_config_path}\n\t"
-                f"Script file: {created_script_path}"
-            ) == captured.records[2].getMessage()
+                f"Script file: {created_script_path}",
+                captured.records,
+            )
 
     def test_create_nodes_from_config_duplicate_node_name(self, cwd):
         """The custom nodes declared in the pipeline file only contains poor
@@ -529,7 +528,8 @@ class TestCliCreateNode:
         with TestCase.assertLogs("peekingduck.cli.logger") as captured:
             CliRunner().invoke(cli, ["create-node", "--config_path", pipeline_file])
             # First 2 message is about info about loading config
-            assert (
+            assert_msg_in_logs(
                 f"{node_string} contains invalid formatting: 'Node name already "
-                "exists!'. Skipping..."
-            ) == captured.records[2].getMessage()
+                "exists!'. Skipping...",
+                captured.records,
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,3 +214,23 @@ def not_raises(exception):
         yield
     except exception:
         raise pytest.fail(f"DID RAISE EXCEPTION: {exception}")
+
+
+def assert_msg_in_logs(msg: str, msg_logs) -> bool:
+    """Helper method to test if given message is in a list of logged messages.
+
+    Args:
+        msg (str): message to check for
+        msg_logs (List[LogRecord]): log of messages
+
+    Returns:
+        bool: True if msg in msgs, otherwise False
+    """
+    print(f"msg_to_check={msg}")
+    print(f"type={type(msg_logs)}")
+    for i, log in enumerate(msg_logs):
+        the_msg = log.getMessage()
+        print(f"{i} {the_msg}")
+        if msg == the_msg:
+            return True
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,17 +216,16 @@ def not_raises(exception):
         raise pytest.fail(f"DID RAISE EXCEPTION: {exception}")
 
 
-def assert_msg_in_logs(msg: str, msg_logs) -> bool:
-    """Helper method to test if given message is in a list of logged messages.
+def assert_msg_in_logs(msg: str, msg_logs) -> None:
+    """Helper method to assert that given message is in a list of logged messages.
 
     Args:
         msg (str): message to check for
         msg_logs (List[LogRecord]): log records containing messages
-
-    Returns:
-        bool: True if msg in msgs, otherwise False
     """
+    res = False
     for log_record in msg_logs:
-        if msg == log_record.getMessage():
-            return True
-    return False
+        if msg in log_record.getMessage():
+            res = True
+            break
+    assert res

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,16 +221,12 @@ def assert_msg_in_logs(msg: str, msg_logs) -> bool:
 
     Args:
         msg (str): message to check for
-        msg_logs (List[LogRecord]): log of messages
+        msg_logs (List[LogRecord]): log records containing messages
 
     Returns:
         bool: True if msg in msgs, otherwise False
     """
-    print(f"msg_to_check={msg}")
-    print(f"type={type(msg_logs)}")
-    for i, log in enumerate(msg_logs):
-        the_msg = log.getMessage()
-        print(f"{i} {the_msg}")
-        if msg == the_msg:
+    for log_record in msg_logs:
+        if msg == log_record.getMessage():
             return True
     return False

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -128,7 +128,6 @@ def test_input_threading():
         while True:
             output = proc.stdout.readline()
             outstr = output.decode("utf-8")
-            print(outstr[:-1])
             if "Avg FPS" in outstr:
                 avg_fps = get_fps_number(outstr)
                 break

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -118,7 +118,8 @@ def test_input_threading():
         avg_fps = 0
         # dotw technotes 2022-06-20:
         # previous `cmd = ["python", PKD_ROOT_DIR.name]` and `.Popen(... cwd=PKD_RUN_DIR, ...)`
-        # breaks when PeekingDuck changes current working directory via full config path
+        # breaks on Linux when PeekingDuck changes current working directory via full config path
+        # (but previous method works properly on macOS and Windows)
         cmd = ["python", "__main__.py"]
         proc = subprocess.Popen(
             cmd,

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -128,6 +128,7 @@ def test_input_threading():
         while True:
             output = proc.stdout.readline()
             outstr = output.decode("utf-8")
+            print(outstr[:-1])
             if "Avg FPS" in outstr:
                 avg_fps = get_fps_number(outstr)
                 break

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -116,10 +116,13 @@ def test_input_threading():
         # run input live test
         num_sec = 60  # to run test for 60 seconds max
         avg_fps = 0
-        cmd = ["python", PKD_ROOT_DIR.name]
+        # dotw technotes 2022-06-20:
+        # previous `cmd = ["python", PKD_ROOT_DIR.name]` and `.Popen(... cwd=PKD_RUN_DIR, ...)`
+        # breaks when PeekingDuck changes current working directory via full config path
+        cmd = ["python", "__main__.py"]
         proc = subprocess.Popen(
             cmd,
-            cwd=PKD_RUN_DIR,
+            cwd=PKD_ROOT_DIR,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=1,

--- a/tests/pipeline/nodes/input/test_input_threading.py
+++ b/tests/pipeline/nodes/input/test_input_threading.py
@@ -141,7 +141,12 @@ def test_input_threading():
         return avg_fps
 
     def run_url_test(the_url: str) -> bool:
+        # show test config
         print(f"url={the_url}")
+        print(f"PKD_ROOT_DIR={PKD_ROOT_DIR}")
+        print(f"PKD_RUN_DIR={PKD_RUN_DIR}")
+        print(f"PKD_PIPELINE_ORIG_PATH={PKD_PIPELINE_ORIG_PATH}")
+
         print("Run test without threading")
         avg_fps_1 = run_rtsp_test(url=the_url, threading=False)
         print("Run test with threading")


### PR DESCRIPTION
The regular `peekingduck run --config_path pipeline.yml` looks for a local pipeline file `pipeline.yml`. The pipeline typically assumes required assets are found locally, within the pipeline file's directory.

However, the user could have multiple pipeline files in different folders, e.g.
```
    parent/
    |---- project_A/
    |     |-- pipeline_A.yml
    |     |-- proj_A.mp4
    |---- project_B/
          |-- pipeline_B.yml
          |-- proj_B.mp4
```
Currently, while in `project_A/`, running `peekingduck run --config_path pipeline_A.yml` works, but running `peekingduck run --config_path /parent/project_B/pipeline_B.yml` fails, because the latter will not be able to locate the asset `proj_B.mp4`.

Solution implemented and changes:
* made internal change to `DeclarativeLoader` class to check: if pipeline config path is a full path starting with `/`, then change current working directory to the pipeline's parent directory.
* otherwise, if pipeilne config path is a local file, nothing changes.
* updated unit tests to work with this new runtime environment change
* also streamlined unit tests with `assert_msg_in_logs()` helper function to search for a message string within a log of output messages: previously, the unit tests check for a certain output message by hardcoding the position index (which will break when the messages order is changed).