### PR TITLE
fix: display window not initializing to the correct aspect ratio and size

### DIFF
--- a/peekingduck/configs/output/screen.yml
+++ b/peekingduck/configs/output/screen.yml
@@ -1,4 +1,4 @@
-input: ["img"]
+input: ["img", "filename"]
 output: ["pipeline_end"]
 
 window_name: "PeekingDuck"

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -19,7 +19,7 @@ Shows the outputs on your display.
 from typing import Any, Dict
 
 import cv2
-
+import numpy as np
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
 
@@ -47,41 +47,77 @@ class Node(AbstractNode):
             with reference from the top left corner of the screen, in pixels.
     """
 
+    ASPECT_RATIO_THRESHOLD = 5e-3
+    MIN_SIZE = 120
+
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
-        self.aspect_ratio_thres = 5e-3
         self.current_filename = None
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
         img = inputs["img"]
-        if not self.window_size["do_resizing"]:
-            img_height, img_width, _ = img.shape
-            if inputs["filename"] is not self.current_filename:
-                # Initialize the window size for every new video
-                cv2.resizeWindow(self.window_name, img_width, img_height)
-                self.current_filename = inputs["filename"]
-            else:
-                # Check the current window size, resize it if aspect ratio is not the same as image
-                aspect_ratio = img_width / img_height
-                _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
-                if abs(win_width / win_height - aspect_ratio) > self.aspect_ratio_thres:
-                    win_height = int(win_width // aspect_ratio)
-                    cv2.resizeWindow(self.window_name, win_width, win_height)
-
-        elif inputs["filename"] is not self.current_filename:
-            # Initialize to config's width and height settings if `do_resizing` is True
-            cv2.resizeWindow(
-                self.window_name, self.window_size["width"], self.window_size["height"]
-            )
-            self.current_filename = inputs["filename"]
-
+        self._set_window_size(inputs["filename"], img)
         cv2.imshow(self.window_name, img)
-
         if cv2.waitKey(1) & 0xFF == ord("q"):
             cv2.destroyWindow(self.window_name)
             return {"pipeline_end": True}
 
         return {"pipeline_end": False}
+
+    def _set_window_size(self, input_filename: str, img: np.ndarray) -> None:
+        """If `do_resizing` option is False, window size will be initialized to the image or
+        video's frame default size. When the user changes the window's size, the aspect ratio
+        will be kept unchanged.
+
+        If `do_resizing` option is True, window size will be initialized to the config setting's
+        width and height for every new video or image. The aspect ratio will not be kept constant
+        when the user changes the size of the display window.
+
+        Args:
+            input_filename (str): The filename from the `inputs` dictionary
+            img (np.ndarray): The current image. The image will not be changed in this function.
+        """
+        if not self.window_size["do_resizing"]:
+            img_height, img_width, _ = img.shape
+            if input_filename != self.current_filename:
+                # Initialize the window size for every new video
+                cv2.resizeWindow(self.window_name, img_width, img_height)
+                self.current_filename = input_filename
+            else:
+                # Check the current window size, resize it if aspect ratio is not the same as image
+                aspect_ratio = img_width / img_height
+                _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
+                if (
+                    abs(win_width / win_height - aspect_ratio)
+                    > self.ASPECT_RATIO_THRESHOLD
+                ):
+                    # Make sure window height and width is above lower bound
+                    win_width = (
+                        win_width if win_width > self.MIN_SIZE else self.MIN_SIZE
+                    )
+                    win_height = int(win_width / aspect_ratio)
+                    if win_height < self.MIN_SIZE:
+                        win_height = self.MIN_SIZE
+                        win_width = int(aspect_ratio * win_height)
+                    cv2.resizeWindow(self.window_name, win_width, win_height)
+        elif input_filename != self.current_filename:
+            # Initialize to config's width and height settings if `do_resizing` is True
+            cv2.resizeWindow(
+                self.window_name, self.window_size["width"], self.window_size["height"]
+            )
+            self.current_filename = input_filename
+        else:
+            # Check to make sure window size do not go below lower bound when `do_resizing` is True
+            _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
+            resize_window = False
+            if win_width < self.MIN_SIZE:
+                win_width = self.MIN_SIZE
+                resize_window = True
+            if win_height < self.MIN_SIZE:
+                win_height = self.MIN_SIZE
+                resize_window = True
+            if resize_window:
+                cv2.resizeWindow(self.window_name, win_width, win_height)

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -91,13 +91,8 @@ class Node(AbstractNode):
             cv2.resizeWindow(self.window_name, img_width, img_height)
             self.previous_filename = current_filename
         else:
-            below_threshold = False
             _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
-            if win_width < MIN_DISPLAY_SIZE:
-                below_threshold = True
-                win_width = MIN_DISPLAY_SIZE
-            elif win_height < MIN_DISPLAY_SIZE:
-                below_threshold = True
-                win_height = MIN_DISPLAY_SIZE
-            if below_threshold:
+            if win_width < MIN_DISPLAY_SIZE or win_height < MIN_DISPLAY_SIZE:
+                win_width = max(win_width, MIN_DISPLAY_SIZE)
+                win_height = max(win_height, MIN_DISPLAY_SIZE)
                 cv2.resizeWindow(self.window_name, win_width, win_height)

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -54,7 +54,7 @@ class Node(AbstractNode):
         super().__init__(config, node_path=__name__, **kwargs)
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
-        self.current_filename = None
+        self.current_filename = ""
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -50,20 +50,12 @@ class Node(AbstractNode):
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
-        self.aspect_ratio_thres = 5e-3
-        if self.window_size["do_resizing"]:
-            # Make sure the window size is initialized to preset settings, if do_resizing is True
-            cv2.resizeWindow(
-                self.window_name, self.window_size["width"], self.window_size["height"]
-            )
-        else:
-            self.current_filename = None
-
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
+        self.aspect_ratio_thres = 5e-3
+        self.current_filename = None
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
-
         img = inputs["img"]
         if not self.window_size["do_resizing"]:
             img_height, img_width, _ = img.shape
@@ -78,6 +70,13 @@ class Node(AbstractNode):
                 if abs(win_width / win_height - aspect_ratio) > self.aspect_ratio_thres:
                     win_height = int(win_width // aspect_ratio)
                     cv2.resizeWindow(self.window_name, win_width, win_height)
+
+        elif inputs["filename"] is not self.current_filename:
+            # Initialize to config's width and height settings if `do_resizing` is True
+            cv2.resizeWindow(
+                self.window_name, self.window_size["width"], self.window_size["height"]
+            )
+            self.current_filename = inputs["filename"]
 
         cv2.imshow(self.window_name, img)
 

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -29,6 +29,8 @@ class Node(AbstractNode):
     Inputs:
         |img_data|
 
+        |filename_data|
+
     Outputs:
         |pipeline_end_data|
 
@@ -55,7 +57,7 @@ class Node(AbstractNode):
                 self.window_name, self.window_size["width"], self.window_size["height"]
             )
         else:
-            self.window_size_init = False
+            self.current_filename = None
 
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
 
@@ -65,10 +67,10 @@ class Node(AbstractNode):
         img = inputs["img"]
         if not self.window_size["do_resizing"]:
             img_height, img_width, _ = img.shape
-            if not self.window_size_init:
-                # Initialize the window size
+            if inputs["filename"] is not self.current_filename:
+                # Initialize the window size for every new video
                 cv2.resizeWindow(self.window_name, img_width, img_height)
-                self.window_size_init = True
+                self.current_filename = inputs["filename"]
             else:
                 # Check the current window size, resize it if aspect ratio is not the same as image
                 aspect_ratio = img_width / img_height

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -54,8 +54,6 @@ class Node(AbstractNode):
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
         cv2.moveWindow(self.window_name, self.window_loc["x"], self.window_loc["y"])
         self.previous_filename = ""
-        self.previous_width = 0
-        self.previous_height = 0
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Show the outputs on your display"""
@@ -86,24 +84,11 @@ class Node(AbstractNode):
             # Initialize the window size for every new video
             if self.window_size["do_resizing"]:
                 # Clamp the sides fo the window_size to have a minimum of MIN_DISPLAY_SIZE
-                self.window_size["width"] = max(
-                    self.window_size["width"], MIN_DISPLAY_SIZE
-                )
-                self.window_size["height"] = max(
-                    self.window_size["height"], MIN_DISPLAY_SIZE
-                )
-                cv2.resizeWindow(
-                    self.window_name,
-                    self.window_size["width"],
-                    self.window_size["height"],
-                )
-                self.previous_width = self.window_size["width"]
-                self.previous_height = self.window_size["height"]
+                img_width = max(self.window_size["width"], MIN_DISPLAY_SIZE)
+                img_height = max(self.window_size["height"], MIN_DISPLAY_SIZE)
             else:
                 img_height, img_width, _ = img.shape
-                cv2.resizeWindow(self.window_name, img_width, img_height)
-                self.previous_width = img_width
-                self.previous_height = img_height
+            cv2.resizeWindow(self.window_name, img_width, img_height)
             self.previous_filename = current_filename
         else:
             below_threshold = False

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -22,6 +22,8 @@ import cv2
 import numpy as np
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
+MIN_DISPLAY_SIZE = 120
+
 
 class Node(AbstractNode):
     """Streams the output on your display.
@@ -46,8 +48,6 @@ class Node(AbstractNode):
             X and Y coordinates of the top left corner of the displayed window,
             with reference from the top left corner of the screen, in pixels.
     """
-
-    MIN_SIZE = 120
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
@@ -76,7 +76,7 @@ class Node(AbstractNode):
         width and height for every new video or image.
 
         The length of either sides of the display window will be clamped to a lower bound of
-        `self.MIN_SIZE`
+        `MIN_DISPLAY_SIZE`
 
         Args:
             current_filename (str): The filename from the `inputs` dictionary
@@ -85,12 +85,12 @@ class Node(AbstractNode):
         if current_filename != self.previous_filename:
             # Initialize the window size for every new video
             if self.window_size["do_resizing"]:
-                # Clamp the sides fo the window_size to have a minimum of self.MIN_SIZE
+                # Clamp the sides fo the window_size to have a minimum of MIN_DISPLAY_SIZE
                 self.window_size["width"] = max(
-                    self.window_size["width"], self.MIN_SIZE
+                    self.window_size["width"], MIN_DISPLAY_SIZE
                 )
                 self.window_size["height"] = max(
-                    self.window_size["height"], self.MIN_SIZE
+                    self.window_size["height"], MIN_DISPLAY_SIZE
                 )
                 cv2.resizeWindow(
                     self.window_name,
@@ -108,11 +108,11 @@ class Node(AbstractNode):
         else:
             below_threshold = False
             _, _, win_width, win_height = cv2.getWindowImageRect(self.window_name)
-            if win_width < self.MIN_SIZE:
+            if win_width < MIN_DISPLAY_SIZE:
                 below_threshold = True
-                win_width = self.MIN_SIZE
-            elif win_height < self.MIN_SIZE:
+                win_width = MIN_DISPLAY_SIZE
+            elif win_height < MIN_DISPLAY_SIZE:
                 below_threshold = True
-                win_height = self.MIN_SIZE
+                win_height = MIN_DISPLAY_SIZE
             if below_threshold:
                 cv2.resizeWindow(self.window_name, win_width, win_height)


### PR DESCRIPTION
Changes made to the behaviour of the `output.screen` node:

1. When `do_resizing` option is set to `True`, display window can now be initialized to the preset width and height specified in the config setting, and user can change the window size and aspect ratio in any way they want without affecting the subsequent run.
2. When `do_resizing` option is set to `False`, the display window will be initialized to the frame's aspect ratio and size, and user can change the window size and aspect ratio in any way they want without affecting the subsequent run. ~~and when the user uses the mouse the change the window size, it will maintain a fixed aspect ratio, (i.e. user can only change the window size by dragging the 2 vertical sides of the display window.)~~
3.  Minimum window size is set to prevent errors when the window size is too small

FPS difference (Tested on personal computer without GPU just for reference)
_Config Settings:_
```yaml
nodes:
  - input.visual:
      source: https://storage.googleapis.com/peekingduck/videos/wave.mp4
  - model.yolox:
      detect: ["person"]
  - draw.bbox:
      show_labels: true
  - dabble.fps
  - output.screen:
      window_size:
        do_resizing: true
        width: 710
        height: 540
```

**With** the method `self._set_window_size`: FPS ~12.71
**Without** the method `self._set_window_size`: FPS ~12.83 

