### PR TITLE
Fix `draw.legend` legend box width and allow changing of font size and thickness

### DIFF
--- a/peekingduck/configs/draw/legend.yml
+++ b/peekingduck/configs/draw/legend.yml
@@ -1,10 +1,11 @@
 input: ["all"]
 output: ["img"]
 
-position: "bottom"
+
 box_opacity: 0.3
-show: []
 font: {
-  size: 0.5,
+  size: 0.7,
   thickness: 2
 }
+position: "bottom"
+show: []

--- a/peekingduck/configs/draw/legend.yml
+++ b/peekingduck/configs/draw/legend.yml
@@ -4,3 +4,7 @@ output: ["img"]
 position: "bottom"
 box_opacity: 0.3
 show: []
+font: {
+  size: 0.5,
+  thickness: 2
+}

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -85,7 +85,8 @@ class Node(AbstractNode):
             outputs (dict): Dictionary with keys "none".
         """
         _check_data_type(inputs, self.show)
-        Legend().draw(inputs, self.show, self.position, self.box_opacity)
+        legend = Legend(self.show, self.position, self.box_opacity, self.font)
+        legend.draw(inputs)
         # cv2 weighted does not update the referenced image. Need to return and replace.
         return {"img": inputs["img"]}
 

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -50,15 +50,22 @@ class Node(AbstractNode):
         |img_data|
 
     Configs:
+        box_opacity (:obj:`float`): **default = 0.3**. |br|
+            Opacity of legend box. A value of 0.0 causes the legend box to be fully transparent,
+            while a value of 1.0 causes it to be fully opaque.
+        font (:obj:`Dict`): **default = {size: 0.7, thickness: 2}.** |br|
+            Size and thickness of font within legend box. Examples of visually acceptable options
+            are: |br|
+            720p video: {size: 0.7, thickness: 2} |br|
+            1080p video: {size: 1.0, thickness: 3}
         position (:obj:`str`): **{"top", "bottom"}, default = "bottom"**. |br|
-            Position to draw legend box. "top" draws it at the top-left
-            position while "bottom" draws it at bottom-left.
+            Position to draw legend box. "top" draws it at the top-left position while "bottom"
+            draws it at bottom-left.
         show (:obj:`List[str]`): **default = []**. |br|
-            Include in this list the desired data type(s) to be drawn within
-            the legend box, such as ``["fps", "count", "cum_avg"]`` in the
-            example screenshot. Custom data types produced by custom nodes are
-            also supported. If no data types are included, an error will be
-            produced.
+            Include in this list the desired data type(s) to be drawn within the legend box, such
+            as ``["fps", "count", "cum_avg"]`` in the example screenshot. Custom data types
+            produced by custom nodes are also supported. If no data types are included, an error
+            will be produced.
 
     .. versionchanged:: 1.2.0
         Merged previous ``all_legend_items`` and ``include`` configs into a

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -51,8 +51,8 @@ class Node(AbstractNode):
 
     Configs:
         box_opacity (:obj:`float`): **default = 0.3**. |br|
-            Opacity of legend box. A value of 0.0 causes the legend box to be fully transparent,
-            while a value of 1.0 causes it to be fully opaque.
+            Opacity of legend box background. A value of 0.0 causes the legend box background to be
+            fully transparent, while a value of 1.0 causes it to be fully opaque.
         font (:obj:`Dict`): **default = {size: 0.7, thickness: 2}.** |br|
             Size and thickness of font within legend box. Examples of visually acceptable options
             are: |br|
@@ -76,6 +76,7 @@ class Node(AbstractNode):
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
+        self.legend = Legend(self.show, self.position, self.box_opacity, self.font)
         if not self.show:
             raise KeyError(
                 "To display information in the legend box, at least one data type must be "
@@ -92,8 +93,7 @@ class Node(AbstractNode):
             outputs (dict): Dictionary with keys "none".
         """
         _check_data_type(inputs, self.show)
-        legend = Legend(self.show, self.position, self.box_opacity, self.font)
-        legend.draw(inputs)
+        self.legend.draw(inputs)
         # cv2 weighted does not update the referenced image. Need to return and replace.
         return {"img": inputs["img"]}
 

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -53,7 +53,7 @@ class Node(AbstractNode):
         box_opacity (:obj:`float`): **default = 0.3**. |br|
             Opacity of legend box background. A value of 0.0 causes the legend box background to be
             fully transparent, while a value of 1.0 causes it to be fully opaque.
-        font (:obj:`Dict`): **default = {size: 0.7, thickness: 2}.** |br|
+        font (:obj:`Dict[str, Union[float, int]]`): **default = {size: 0.7, thickness: 2}.** |br|
             Size and thickness of font within legend box. Examples of visually acceptable options
             are: |br|
             720p video: {size: 0.7, thickness: 2} |br|

--- a/peekingduck/pipeline/nodes/draw/utils/legend.py
+++ b/peekingduck/pipeline/nodes/draw/utils/legend.py
@@ -16,7 +16,7 @@
 functions for drawing legend related UI components
 """
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import cv2
 import numpy as np
@@ -32,6 +32,7 @@ from peekingduck.pipeline.nodes.draw.utils.constants import (
 from peekingduck.pipeline.nodes.draw.utils.general import get_image_size
 
 ZONE_COUNTS_HEADING = "-ZONE COUNTS-"
+LEGEND_LEFT_X = 15
 
 
 class Legend:  # pylint: disable=too-many-instance-attributes
@@ -51,22 +52,13 @@ class Legend:  # pylint: disable=too-many-instance-attributes
         self.font_thickness = font["thickness"]
 
         self.frame = None
-        self.legend_left_x = 15
         self.legend_starting_y = 0
-        self.delta_y = 0
+        self.legend_width = 0
         self.legend_height = 0
-        self.item_height = cv2.getTextSize(
-            "",
-            FONT_HERSHEY_SIMPLEX,
-            self.font_size,
-            self.font_thickness,
-        )[0][1]
+        self.item_height = self._get_text_size("")[1]
         self.item_padding = self.item_height // 2
 
-    def draw(
-        self,
-        inputs: Dict[str, Any],
-    ) -> np.ndarray:
+    def draw(self, inputs: Dict[str, Any]) -> None:
         """Draw legends onto image
 
         Args:
@@ -74,20 +66,111 @@ class Legend:  # pylint: disable=too-many-instance-attributes
         """
         self.frame = inputs["img"]
 
-        self.legend_height = self._get_legend_height(inputs)
-        self.legend_width = self._get_legend_width(inputs)
-        self._set_legend_variables()
-
+        # legend box has to be drawn first to be "behind" text
+        self._update_legend_size(inputs)
+        self._set_legend_starting_y()
         self._draw_legend_box(self.frame)
         y_pos = self.legend_starting_y + self.item_height
+
         for item in self.items:
             if item == "zone_count":
                 self._draw_zone_count(self.frame, y_pos, inputs[item])
             else:
-                self.draw_item_info(self.frame, y_pos, item, inputs[item])
+                self._draw_item_info(self.frame, y_pos, item, inputs[item])
             y_pos += self.item_height + self.item_padding
 
-    def draw_item_info(
+    def _update_legend_size(self, inputs: Dict[str, Any]) -> None:
+        """Update the width and height of the legend box"""
+        self.legend_height = self._get_legend_height(inputs)
+        self.legend_width = max(self.legend_width, self._get_legend_width(inputs))
+
+    def _get_legend_height(self, inputs: Dict[str, Any]) -> int:
+        """Get height of legend box needed to contain all items drawn"""
+        num_items = len(self.items)
+        if "zone_count" in self.items:
+            # increase the number of items according to number of zones
+            num_items += len(inputs["zone_count"])
+        return (self.item_height + self.item_padding) * num_items
+
+    def _get_legend_width(self, inputs: Dict[str, Any]) -> int:
+        """Get width of legend box needed to contain all items drawn"""
+        max_width = 0
+        for item in self.items:
+            if item != "zone_count":
+                max_width = max(max_width, self._get_item_width(item, inputs[item]))
+            else:
+                max_width = self._get_item_width(ZONE_COUNTS_HEADING, "")
+                for i, count in enumerate(inputs[item]):
+                    max_width = max(
+                        max_width,
+                        self._get_item_width(f"ZONE-{i+1}", count)
+                        + self.item_padding
+                        + self.item_height,
+                    )
+
+        return max_width + 2 * self.item_padding
+
+    def _get_item_width(
+        self,
+        item_name: str,
+        item_info: Union[int, float, str],
+    ) -> int:
+        """Get width of the text to be drawn. If item info is
+        of float type, it will be displayed in 2 decimal places.
+
+        Args:
+            item_name (str): name of the legend item
+            item_info: Union[int, float, str]: info contained by the legend item
+        """
+        if not isinstance(item_info, (int, float, str)):
+            raise TypeError(
+                f"With the exception of the 'zone_count' data type, "
+                f"the draw.legend node only draws values that are of type 'int', 'float' or 'str' "
+                f"within the legend box. The value: {item_info} from the data type: {item_name} "
+                f"is of type: {type(item_info)} and is unable to be drawn."
+            )
+
+        if isinstance(item_info, float):
+            text = f"{item_name.upper()}: {item_info:.2f}"
+        else:
+            text = f"{item_name.upper()}: {str(item_info)}"
+
+        return self._get_text_size(text)[0]
+
+    def _set_legend_starting_y(self) -> None:
+        assert self.legend_height != 0
+        if self.position == "top":
+            self.legend_starting_y = self.item_padding
+        else:
+            _, image_height = get_image_size(self.frame)
+            self.legend_starting_y = (
+                image_height - self.item_padding - self.legend_height
+            )
+
+    def _draw_legend_box(self, frame: np.ndarray) -> None:
+        """draw pts of selected object onto frame
+
+        Args:
+            frame (np.array): image of current frame
+        """
+        assert self.legend_height is not None
+        overlay = frame.copy()
+        cv2.rectangle(
+            overlay,
+            (LEGEND_LEFT_X, self.legend_starting_y - self.item_padding),
+            (
+                LEGEND_LEFT_X + self.legend_width,
+                self.legend_starting_y + self.legend_height,
+            ),
+            BLACK,
+            FILLED,
+        )
+        # apply the overlay
+        cv2.addWeighted(
+            overlay, self.box_opacity, frame, 1 - self.box_opacity, 0, frame
+        )
+
+    def _draw_item_info(
         self,
         frame: np.ndarray,
         y_pos: int,
@@ -117,16 +200,7 @@ class Legend:  # pylint: disable=too-many-instance-attributes
             text = f"{item_name.upper()}: {item_info:.2f}"
         else:
             text = f"{item_name.upper()}: {str(item_info)}"
-        cv2.putText(
-            frame,
-            text,
-            (self.legend_left_x + self.item_padding, y_pos),
-            FONT_HERSHEY_SIMPLEX,
-            self.font_size,
-            WHITE,
-            self.font_thickness,
-            LINE_AA,
-        )
+        self._put_text(frame, text, (LEGEND_LEFT_X + self.item_padding, y_pos))
 
     def _draw_zone_count(
         self, frame: np.ndarray, y_pos: int, counts: List[int]
@@ -138,127 +212,46 @@ class Legend:  # pylint: disable=too-many-instance-attributes
             y_pos (int): y position to draw the count info text
             counts (list): list of zone counts
         """
-        cv2.putText(
-            frame,
-            ZONE_COUNTS_HEADING,
-            (self.legend_left_x + self.item_padding, y_pos),
-            FONT_HERSHEY_SIMPLEX,
-            self.font_size,
-            WHITE,
-            self.font_thickness,
-            LINE_AA,
+        self._put_text(
+            frame, ZONE_COUNTS_HEADING, (LEGEND_LEFT_X + self.item_padding, y_pos)
         )
         for i, count in enumerate(counts):
             y_pos += self.item_height + self.item_padding
             cv2.rectangle(
                 frame,
-                (self.legend_left_x + self.item_padding, y_pos),
+                (LEGEND_LEFT_X + self.item_padding, y_pos),
                 (
-                    self.legend_left_x + self.item_padding + self.item_height,
+                    LEGEND_LEFT_X + self.item_padding + self.item_height,
                     y_pos - self.item_height,
                 ),
                 PRIMARY_PALETTE[(i + 1) % PRIMARY_PALETTE_LENGTH],
                 FILLED,
             )
             text = f" ZONE-{i+1}: {count}"
-            cv2.putText(
+            self._put_text(
                 frame,
                 text,
-                (self.legend_left_x + self.item_padding + self.item_height, y_pos),
-                FONT_HERSHEY_SIMPLEX,
-                self.font_size,
-                WHITE,
-                self.font_thickness,
-                LINE_AA,
+                (LEGEND_LEFT_X + self.item_padding + self.item_height, y_pos),
             )
 
-    def _draw_legend_box(self, frame: np.ndarray) -> None:
-        """draw pts of selected object onto frame
-
-        Args:
-            frame (np.array): image of current frame
-        """
-        assert self.legend_height is not None
-        overlay = frame.copy()
-        cv2.rectangle(
-            overlay,
-            (self.legend_left_x, self.legend_starting_y - self.item_padding),
-            (
-                self.legend_left_x + self.legend_width,
-                self.legend_starting_y + self.legend_height,
-            ),
-            BLACK,
-            FILLED,
-        )
-        # apply the overlay
-        cv2.addWeighted(
-            overlay, self.box_opacity, frame, 1 - self.box_opacity, 0, frame
-        )
-
-    def _get_legend_height(self, inputs: Dict[str, Any]) -> int:
-        """Get height of legend box needed to contain all items drawn"""
-        no_of_items = len(self.items)
-        if "zone_count" in self.items:
-            # increase the number of items according to number of zones
-            no_of_items += len(inputs["zone_count"])
-        return (self.item_height + self.item_padding) * no_of_items
-
-    def _get_item_width(
-        self,
-        item_name: str,
-        item_info: Union[int, float, str],
-    ) -> int:
-        """Get width of the text to be drawn. If item info is
-        of float type, it will be displayed in 2 decimal places.
-
-        Args:
-            item_name (str): name of the legend item
-            item_info: Union[int, float, str]: info contained by the legend item
-        """
-        if not isinstance(item_info, (int, float, str)):
-            raise TypeError(
-                f"With the exception of the 'zone_count' data type, "
-                f"the draw.legend node only draws values that are of type 'int', 'float' or 'str' "
-                f"within the legend box. The value: {item_info} from the data type: {item_name} "
-                f"is of type: {type(item_info)} and is unable to be drawn."
-            )
-
-        if isinstance(item_info, float):
-            text = f"{item_name.upper()}: {item_info:.2f}"
-        else:
-            text = f"{item_name.upper()}: {str(item_info)}"
-
-        text_size = cv2.getTextSize(
+    def _get_text_size(self, text: str) -> Tuple[int, int]:
+        """Wrapper around cv2.getTextSize method to reduce number of arguments in calls"""
+        return cv2.getTextSize(
             text,
             FONT_HERSHEY_SIMPLEX,
             self.font_size,
             self.font_thickness,
+        )[0]
+
+    def _put_text(self, frame: np.ndarray, text: str, pos: Tuple[int, int]) -> None:
+        """Wrapper around cv2.putText method to reduce number of arguments in calls"""
+        cv2.putText(
+            frame,
+            text,
+            pos,
+            FONT_HERSHEY_SIMPLEX,
+            self.font_size,
+            WHITE,
+            self.font_thickness,
+            LINE_AA,
         )
-
-        return text_size[0][0]
-
-    def _get_legend_width(self, inputs: Dict[str, Any]) -> int:
-        """Get width of legened box needed to contain all items drawn"""
-        max_width = 0
-        for item in self.items:
-            if item != "zone_count":
-                max_width = max(max_width, self._get_item_width(item, inputs[item]))
-            else:
-                max_width = cv2.getTextSize(
-                    ZONE_COUNTS_HEADING,
-                    FONT_HERSHEY_SIMPLEX,
-                    self.font_size,
-                    self.font_thickness,
-                )[0][0]
-
-        return max_width + 2 * self.item_padding
-
-    def _set_legend_variables(self) -> None:
-        assert self.legend_height != 0
-        if self.position == "top":
-            self.legend_starting_y = self.item_padding
-        else:
-            _, image_height = get_image_size(self.frame)
-            self.legend_starting_y = (
-                image_height - self.item_padding - self.legend_height
-            )

--- a/peekingduck/pipeline/nodes/draw/utils/legend.py
+++ b/peekingduck/pipeline/nodes/draw/utils/legend.py
@@ -35,7 +35,7 @@ ZONE_COUNTS_HEADING = "-ZONE COUNTS-"
 LEGEND_LEFT_X = 15
 
 
-class Legend:  # pylint: disable=too-many-instance-attributes
+class Legend:  # pylint: disable=too-many-instance-attributes, too-few-public-methods
     """Legend class that uses available info to draw legend box on frame"""
 
     def __init__(

--- a/tests/pipeline/nodes/draw/test_legend.py
+++ b/tests/pipeline/nodes/draw/test_legend.py
@@ -31,6 +31,7 @@ def draw_legend_bottom():
             "show": ["fps", "count", "zone_count"],
             "position": "bottom",
             "box_opacity": 0.3,
+            "font": {"size": 0.7, "thickness": 2},
         }
     )
     return node
@@ -45,6 +46,7 @@ def draw_legend_top():
             "show": ["fps", "count", "zone_count"],
             "position": "top",
             "box_opacity": 0.3,
+            "font": {"size": 0.7, "thickness": 2},
         }
     )
     return node

--- a/tests/pipeline/nodes/draw/test_legend.py
+++ b/tests/pipeline/nodes/draw/test_legend.py
@@ -61,6 +61,8 @@ class TestLegend:
                     "output": ["img"],
                     "show": [],
                     "position": "bottom",
+                    "box_opacity": 0.3,
+                    "font": {"size": 0.7, "thickness": 2},
                 }
             )
         assert (


### PR DESCRIPTION
closes #675 and #676.

Main changes:
- Fixed bug where the legend box is very thin and doesn't stretch across the entire width of text for zone counting
- Added improvement where font size of text within legend box can now be configured as follows:
```
font: {
  size: 0.7,
  thickness: 2
}
```
Other improvements include removing most hardcoded variables in `utils/legend.py`. 