### PR TITLE
Fix setup.cfg, add setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,9 @@ include_package_data = True
 [options.package_data]
 * =
     configs/*/*.yml
+    configs/node_template.yml
     optional_requirements.txt
+    pipeline/nodes/model/master_map.yml
     viewer/PeekingDuckLogo.png
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+# Copyright 2022 AI Singapore
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dummy setup.py : for older systems/pip versions that need this
+"""
+
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
Fix `pip install .` problems for older systems (e.g. Nvidia Jetson Ubuntu 18.04):
- add back `node_template.yml` and `master_map.yml` to `setup.cfg` for older pip versions
- add dummy `setup.py` for systems that cannot use `pyproject.toml`