### PR TITLE
Feat: config type checking

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -9,4 +9,5 @@ tensorflow == 2.2.0
 torch == 1.10.0
 torchvision == 0.11.1
 tqdm == 4.45.0
+typeguard >= 2.13.3
 scipy >= 1.4.1

--- a/peekingduck/configs/draw/group_bbox_and_tag.yml
+++ b/peekingduck/configs/draw/group_bbox_and_tag.yml
@@ -1,6 +1,4 @@
 input: ["img", "bboxes", "obj_attrs", "large_groups"]
 output: ["none"]
 
-bbox_color: [0, 140, 255]
-bbox_thickness: 4
 tag: "LARGE GROUP!"

--- a/peekingduck/configs/draw/poses.yml
+++ b/peekingduck/configs/draw/poses.yml
@@ -1,7 +1,2 @@
 input: ["keypoints", "keypoint_scores", "keypoint_conns", "img"]
 output: ["none"]
-
-keypoint_dot_color: [0, 255, 0]
-keypoint_dot_radius: 5
-keypoint_connect_color: [0, 255, 255]
-keypoint_text_color: [255, 0, 255]

--- a/peekingduck/configs/output/media_writer.yml
+++ b/peekingduck/configs/output/media_writer.yml
@@ -1,4 +1,4 @@
 input: ["img", "filename", "saved_video_fps", "pipeline_end"]
 output: ["none"]
 
-output_dir: 'PeekingDuck/data/output'
+output_dir: "PeekingDuck/data/output"

--- a/peekingduck/pipeline/nodes/abstract_node.py
+++ b/peekingduck/pipeline/nodes/abstract_node.py
@@ -143,7 +143,7 @@ class AbstractNode(metaclass=ABCMeta):
         `config_types`. Recursively checks each value of dictionaries.
         """
         for key in config:
-            full_key = parent + key
+            full_key = f"{parent}{key}"
             if isinstance(config[key], dict):
                 self._check_type(config[key], config_types, f"{full_key}.")
             config_type = config_types.get(full_key, Any)

--- a/peekingduck/pipeline/nodes/abstract_node.py
+++ b/peekingduck/pipeline/nodes/abstract_node.py
@@ -174,7 +174,5 @@ class AbstractNode(metaclass=ABCMeta):
         return dict_orig
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {}

--- a/peekingduck/pipeline/nodes/abstract_node.py
+++ b/peekingduck/pipeline/nodes/abstract_node.py
@@ -22,6 +22,8 @@ from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from typeguard import check_type
+
 from peekingduck.config_loader import ConfigLoader
 from peekingduck.utils.detect_id_mapper import obj_det_change_class_name_to_id
 
@@ -129,9 +131,23 @@ class AbstractNode(metaclass=ABCMeta):
             updated_config = self._edit_config(loaded_config, kwargs_config)
             self.config = updated_config
 
+        self._check_type(self.config, self._get_config_types())
         # sets class attributes
         for key in self.config:
             setattr(self, key, self.config[key])
+
+    def _check_type(
+        self, config: Dict[str, Any], config_types: Dict[str, Any], parent: str = ""
+    ) -> None:
+        """Checks the typing of the config values against the provided
+        `config_types`. Recursively checks each value of dictionaries.
+        """
+        for key in config:
+            full_key = parent + key
+            if isinstance(config[key], dict):
+                self._check_type(config[key], config_types, f"{full_key}.")
+            config_type = config_types.get(full_key, Any)
+            check_type(f"{self.node_name}'s `{full_key}`", config[key], config_type)
 
     def _edit_config(
         self,
@@ -155,3 +171,9 @@ class AbstractNode(metaclass=ABCMeta):
                         f"Config for node {self.node_name} is updated to: '{key}': {value}"
                     )
         return dict_orig
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {}

--- a/peekingduck/pipeline/nodes/abstract_node.py
+++ b/peekingduck/pipeline/nodes/abstract_node.py
@@ -60,9 +60,10 @@ class AbstractNode(metaclass=ABCMeta):
         # the nodes' config file
         self.optional_inputs: List[str]
 
-        # NOTE: config and kwargs_config are similar but are from different
-        # inputs config is when users input a dictionary to update the node
-        # kwargs_config is when users input parameters to update the node
+        # NOTE: ``config`` and ``kwargs_config`` are similar but are from
+        # different inputs. ``config`` is when users input a dictionary to
+        # update the node. ``kwargs_config`` is when users input parameters to
+        # update the node
         self.config_loader = ConfigLoader(pkd_base_dir)
         self.load_node_config(config, kwargs)  # type: ignore
 

--- a/peekingduck/pipeline/nodes/augment/brightness.py
+++ b/peekingduck/pipeline/nodes/augment/brightness.py
@@ -63,3 +63,9 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         img = np.reshape(img_vector, orig_shape)
 
         return {"img": img}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"beta": int}

--- a/peekingduck/pipeline/nodes/augment/brightness.py
+++ b/peekingduck/pipeline/nodes/augment/brightness.py
@@ -65,7 +65,5 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         return {"img": img}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"beta": int}

--- a/peekingduck/pipeline/nodes/augment/contrast.py
+++ b/peekingduck/pipeline/nodes/augment/contrast.py
@@ -60,7 +60,5 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         return {"img": img}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"alpha": float}

--- a/peekingduck/pipeline/nodes/augment/contrast.py
+++ b/peekingduck/pipeline/nodes/augment/contrast.py
@@ -58,3 +58,9 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         img = cv2.convertScaleAbs(inputs["img"], alpha=self.alpha, beta=0)
 
         return {"img": img}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"alpha": float}

--- a/peekingduck/pipeline/nodes/augment/undistort.py
+++ b/peekingduck/pipeline/nodes/augment/undistort.py
@@ -61,7 +61,6 @@ class Node(AbstractNode):
         super().__init__(config, node_path=__name__, **kwargs)
 
         self.file_path = Path(self.file_path)  # type: ignore
-        # check if file_path has a ".yml" extension
         if self.file_path.suffix != ".yml":
             raise ValueError("Filepath must have a '.yml' extension.")
         if not self.file_path.exists():

--- a/peekingduck/pipeline/nodes/augment/undistort.py
+++ b/peekingduck/pipeline/nodes/augment/undistort.py
@@ -16,13 +16,12 @@
 Removes distortion from a wide-angle camera image.
 """
 
-
+from pathlib import Path
 from typing import Any, Dict
 
-from pathlib import Path
 import cv2
-import yaml
 import numpy as np
+import yaml
 
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
@@ -87,7 +86,6 @@ class Node(AbstractNode):
         Returns:
             outputs (dict): Outputs dictionary with the key `img`.
         """
-
         img = inputs["img"]
 
         if self.new_camera_matrix is None:
@@ -112,3 +110,9 @@ class Node(AbstractNode):
         undistorted_img = undistorted_img[y_pos : y_pos + img_h, x_pos : x_pos + img_w]
 
         return {"img": undistorted_img}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"file_path": str}

--- a/peekingduck/pipeline/nodes/augment/undistort.py
+++ b/peekingduck/pipeline/nodes/augment/undistort.py
@@ -111,7 +111,5 @@ class Node(AbstractNode):
         return {"img": undistorted_img}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"file_path": str}

--- a/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
@@ -54,8 +54,7 @@ class Node(AbstractNode):
         locations = []
 
         for bbox in inputs["bboxes"]:
-            # Subtraction is to make the camera the origin of the coordinate
-            # system
+            # Subtraction is to make the camera the origin of the coordinate system
             center_2d = ((bbox[0:2] + bbox[2:4]) * 0.5) - np.array([0.5, 0.5])
             bbox_height = bbox[3] - bbox[1]
 

--- a/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
@@ -70,7 +70,5 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"focal_length": float, "height_factor": float}

--- a/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/bbox_to_3d_loc.py
@@ -69,3 +69,9 @@ class Node(AbstractNode):
         outputs = {"obj_3D_locs": locations}
 
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"focal_length": float, "height_factor": float}

--- a/peekingduck/pipeline/nodes/dabble/camera_calibration.py
+++ b/peekingduck/pipeline/nodes/dabble/camera_calibration.py
@@ -17,17 +17,17 @@ Calculates camera coefficients to be used to
 remove distortion from a wide-angle camera image.
 """
 
-from typing import Any, Dict, List
-
-from pathlib import Path
 import math
 import time
+from pathlib import Path
+from typing import Any, Dict, List
+
 import cv2
-import yaml
 import numpy as np
+import yaml
 
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
-from peekingduck.pipeline.nodes.draw.utils.constants import CHAMPAGNE, BLACK, TOMATO
+from peekingduck.pipeline.nodes.draw.utils.constants import BLACK, CHAMPAGNE, TOMATO
 
 # global constants
 # terminal criteria for subpixel finetuning
@@ -173,7 +173,7 @@ class Node(AbstractNode):
         gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         height, width = img.shape[:2]
 
-        self._initialise_display_scales(width)
+        self._initialize_display_scales(width)
         start_point, end_point, text_pos = _get_box_info(
             self.num_detections, width, height
         )
@@ -222,9 +222,14 @@ class Node(AbstractNode):
 
         return {"img": img}
 
-    def _initialise_display_scales(self, img_width: int) -> None:
-        """Initalises display scales if it hasn't been initialised before"""
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"num_corners": List[int], "scale_factor": int, "file_path": str}
 
+    def _initialize_display_scales(self, img_width: int) -> None:
+        """Initializes display scales if it hasn't been initialized before"""
         if not self.display_scales:
             self.display_scales = {
                 "box_thickness": max(int(img_width * BOX_THICKNESS_RATIO), 1),
@@ -256,7 +261,6 @@ class Node(AbstractNode):
 
     def _calculate_coeffs(self, img_shape: tuple) -> tuple:
         """Performs calculations with detected corners"""
-
         calibration_data = cv2.calibrateCamera(
             objectPoints=self.object_points,
             imagePoints=self.image_points,
@@ -284,7 +288,6 @@ class Node(AbstractNode):
 
     def _write_coeffs(self, calibration_data: tuple) -> None:
         """Writes camera coefficients to a file"""
-
         (_, camera_matrix, distortion_coeffs, _, _) = calibration_data
 
         file_data = {}
@@ -295,7 +298,6 @@ class Node(AbstractNode):
 
     def _calculate_error(self, calibration_data: tuple) -> None:
         """Calculates re-projection error"""
-
         (
             _,
             camera_matrix,
@@ -332,7 +334,6 @@ class Node(AbstractNode):
         text_pos: tuple,
     ) -> None:
         """Draws text and corners on image"""
-
         # improve corner accuracy
         corners_accurate = cv2.cornerSubPix(
             image=gray_img,
@@ -370,7 +371,6 @@ class Node(AbstractNode):
         self, img: np.ndarray, text_to_draw: List[str], text_pos: tuple
     ) -> None:
         """Draws text and countdown on image"""
-
         _draw_text(
             img=img,
             texts=text_to_draw,
@@ -448,7 +448,6 @@ def _check_corners_validity(
     width: int, height: int, corners: np.ndarray, start_point: tuple, end_point: tuple
 ) -> int:
     """Checks whether the corners are large enough and fall within the box"""
-
     min_w = width
     min_h = height
     max_w = 0
@@ -490,7 +489,6 @@ def _draw_box(
     img: np.ndarray, start_point: tuple, end_point: tuple, box_thickness: int
 ) -> None:
     """Draws rectangle on the image"""
-
     cv2.rectangle(
         img=img,
         pt1=start_point,
@@ -514,7 +512,6 @@ def _draw_bgnd_box(
     pt2: tuple,
 ) -> None:
     """Draws background box on image"""
-
     box_img = img.copy()
 
     # draw the rectangle
@@ -532,7 +529,6 @@ def _draw_text(
     thickness: int,
 ) -> None:
     """Draws text on the image"""
-
     pos, pos_type = pos_info
 
     text_width = 0
@@ -599,7 +595,6 @@ def _draw_countdown(
     img: np.ndarray, num: int, font_scale: float, thickness: int
 ) -> None:
     """Draws a countdown in the center of the screen"""
-
     height, width = img.shape[:2]
 
     text = str(num)

--- a/peekingduck/pipeline/nodes/dabble/camera_calibration.py
+++ b/peekingduck/pipeline/nodes/dabble/camera_calibration.py
@@ -223,9 +223,7 @@ class Node(AbstractNode):
         return {"img": img}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"num_corners": List[int], "scale_factor": int, "file_path": str}
 
     def _initialize_display_scales(self, img_width: int) -> None:

--- a/peekingduck/pipeline/nodes/dabble/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/dabble/check_large_groups.py
@@ -62,7 +62,5 @@ class Node(AbstractNode):
         return {"large_groups": large_groups}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"group_size_threshold": int}

--- a/peekingduck/pipeline/nodes/dabble/check_large_groups.py
+++ b/peekingduck/pipeline/nodes/dabble/check_large_groups.py
@@ -60,3 +60,9 @@ class Node(AbstractNode):
         ]
 
         return {"large_groups": large_groups}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"group_size_threshold": int}

--- a/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
@@ -76,3 +76,9 @@ class Node(AbstractNode):
                     break
 
         return {"obj_attrs": {"flags": obj_flags}}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"near_threshold": float, "tag_msg": str}

--- a/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/check_nearby_objs.py
@@ -78,7 +78,5 @@ class Node(AbstractNode):
         return {"obj_attrs": {"flags": obj_flags}}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"near_threshold": float, "tag_msg": str}

--- a/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
-from peekingduck.pipeline.nodes.dabble.utils.quick_find import QuickFind
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.dabble.utils.quick_find import QuickFind
 
 
 class Node(AbstractNode):
@@ -70,6 +70,12 @@ class Node(AbstractNode):
                 quickfind.union(idx_1, idx_2)
 
         return {"obj_attrs": {"groups": quickfind.get_group_alloc()}}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"obj_dist_threshold": float}
 
     @staticmethod
     def _find_nearby_obj_pairs(

--- a/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
+++ b/peekingduck/pipeline/nodes/dabble/group_nearby_objs.py
@@ -72,9 +72,7 @@ class Node(AbstractNode):
         return {"obj_attrs": {"groups": quickfind.get_group_alloc()}}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"obj_dist_threshold": float}
 
     @staticmethod

--- a/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
@@ -73,6 +73,12 @@ class Node(AbstractNode):
 
         return outputs
 
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"focal_length": float, "torso_factor": float}
+
     @staticmethod
     def _get_torso_keypoints(keypoints: np.ndarray) -> np.ndarray:
         """Filter keypoints to get only selected keypoints for torso"""

--- a/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
+++ b/peekingduck/pipeline/nodes/dabble/keypoints_to_3d_loc.py
@@ -74,9 +74,7 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"focal_length": float, "torso_factor": float}
 
     @staticmethod

--- a/peekingduck/pipeline/nodes/dabble/statistics.py
+++ b/peekingduck/pipeline/nodes/dabble/statistics.py
@@ -17,10 +17,10 @@ of interest over time.
 """
 
 import operator
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
-from peekingduck.pipeline.nodes.dabble.statisticsv1 import utils
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.dabble.statisticsv1 import utils
 
 # Order matters so that regex doesn't read ">=" as ">" or "<=" as "<"
 # Dictionaries are insertion ordered from Python 3.6 onwards
@@ -203,9 +203,21 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
             "cum_max": self.cum_max,
         }
 
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "identity": Optional[str],
+            "length": Optional[str],
+            "minimum": Optional[str],
+            "maximum": Optional[str],
+            "cond_count": Optional[str],
+        }
+
     def _update_stats(self, curr: Union[float, int]) -> None:
         """Updates the cum_avg, cum_min and cum_max values with the current value."""
-        if not isinstance(curr, float) and not isinstance(curr, int):
+        if not isinstance(curr, (float, int)):
             raise TypeError(
                 f"The current result has to be of type 'int' or 'float' to calculate statistics."
                 f"However, the current result here is: '{curr}' which is of type: {type(curr)}."

--- a/peekingduck/pipeline/nodes/dabble/statistics.py
+++ b/peekingduck/pipeline/nodes/dabble/statistics.py
@@ -204,9 +204,7 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
         }
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "identity": Optional[str],
             "length": Optional[str],

--- a/peekingduck/pipeline/nodes/dabble/tracking.py
+++ b/peekingduck/pipeline/nodes/dabble/tracking.py
@@ -83,9 +83,7 @@ class Node(AbstractNode):
         return {"obj_attrs": {"ids": track_ids}}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"tracking_type": str, "iou_threshold": float, "max_lost": int}
 
     def _reset_model(self) -> None:

--- a/peekingduck/pipeline/nodes/dabble/tracking.py
+++ b/peekingduck/pipeline/nodes/dabble/tracking.py
@@ -16,10 +16,10 @@
 
 from typing import Any, Dict
 
+from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.dabble.trackingv1.detection_tracker import (
     DetectionTracker,
 )
-from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
 
 class Node(AbstractNode):
@@ -81,6 +81,12 @@ class Node(AbstractNode):
         track_ids = self.tracker.track_detections(inputs)
 
         return {"obj_attrs": {"ids": track_ids}}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"tracking_type": str, "iou_threshold": float, "max_lost": int}
 
     def _reset_model(self) -> None:
         """Creates a new instance of DetectionTracker."""

--- a/peekingduck/pipeline/nodes/dabble/zone_count.py
+++ b/peekingduck/pipeline/nodes/dabble/zone_count.py
@@ -95,9 +95,7 @@ class Node(AbstractNode):
         return created_zone
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"resolution": List[int], "zones": List[List[List[Union[int, float]]]]}
 
     @staticmethod

--- a/peekingduck/pipeline/nodes/dabble/zone_count.py
+++ b/peekingduck/pipeline/nodes/dabble/zone_count.py
@@ -14,10 +14,10 @@
 
 """Counts the number of detected objects within a boundary."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
-from peekingduck.pipeline.nodes.dabble.zoningv1.zone import Zone
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.dabble.zoningv1.zone import Zone
 
 
 class Node(AbstractNode):
@@ -104,6 +104,12 @@ class Node(AbstractNode):
             )
 
         return created_zone
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"resolution": List[int], "zones": List[List[List[Union[int, float]]]]}
 
     @staticmethod
     def _get_pixel_coords(coords: List[float], resolution: List[int]) -> List[float]:

--- a/peekingduck/pipeline/nodes/dabble/zoningv1/zone.py
+++ b/peekingduck/pipeline/nodes/dabble/zoningv1/zone.py
@@ -17,41 +17,27 @@ Creates a zone from a polygon area
 """
 
 from typing import List, Tuple
-from shapely.geometry.polygon import Polygon, Point
+
+from shapely.geometry.polygon import Point, Polygon
 
 
-class Zone:
+class Zone:  # pylint: disable=too-few-public-methods
     """This class uses polygon area to create a zone for counting."""
 
-    def __init__(self, coord_list: List[List[float]]) -> None:
+    def __init__(self, points: List[List[int]]) -> None:
         # Each zone is a polygon created by a list of x, y coordinates
-        self.polygon_points = [tuple(x) for x in coord_list]
+        self.polygon_points = [tuple(point) for point in points]
         self.polygon = Polygon(self.polygon_points)
 
-    def point_within_zone(self, x_coord: float, y_coord: float) -> bool:
-        """Function used to check whether the bottom middle point of the bounding box
-        is within the stipulated zone created by the divider.
+    def contains(self, point: Tuple[float, float]) -> bool:
+        """Checks if the specified point is within the area bounded by the
+        zone.
 
         Args:
-            x (float): middle x position of the bounding box
-            y (float): lowest y position of the bounding box
+            point (Tuple[float, float]): The x- and y- coordinate to check.
 
         Returns:
-            boolean: whether the point given is within the zone.
+            (bool): True if ``point`` is within the zone.
         """
-        return self._is_inside(x_coord, y_coord)
-
-    def get_all_points_of_area(self) -> List[Tuple[float, ...]]:
-        """Function used to Get all (x, y) tuple points that form the area of the zone.
-
-        Args:
-            None
-
-        Returns:
-            list: returns a list of (x, y) points that form the zone area.
-        """
-        return self.polygon_points
-
-    def _is_inside(self, x_coord: float, y_coord: float) -> bool:
-        point = Point((x_coord, y_coord))
+        point = Point(point)
         return self.polygon.buffer(1).contains(point)

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -55,7 +55,5 @@ class Node(AbstractNode):
         return {}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"show_labels": bool}

--- a/peekingduck/pipeline/nodes/draw/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/bbox.py
@@ -18,8 +18,8 @@ Draws bounding boxes over detected objects.
 
 from typing import Any, Dict
 
-from peekingduck.pipeline.nodes.draw.utils.bbox import draw_bboxes
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.draw.utils.bbox import draw_bboxes
 
 
 class Node(AbstractNode):
@@ -53,3 +53,9 @@ class Node(AbstractNode):
             inputs["img"], inputs["bboxes"], inputs["bbox_labels"], self.show_labels
         )
         return {}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"show_labels": bool}

--- a/peekingduck/pipeline/nodes/draw/blur_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/blur_bbox.py
@@ -84,3 +84,9 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         blurred_img = self._blur(inputs["bboxes"], inputs["img"], self.blur_kernel_size)
         outputs = {"img": blurred_img}
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"blue_kernel_size": int}

--- a/peekingduck/pipeline/nodes/draw/blur_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/blur_bbox.py
@@ -47,13 +47,30 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
 
-        self.blur_kernel_size = self.config["blur_kernel_size"]
+    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Reads the image input and returns the image, with the areas bounded
+        by the bboxes blurred.
 
-    @staticmethod
-    def _blur(
-        bboxes: List[np.ndarray], image: np.ndarray, blur_kernel_size: int
-    ) -> np.ndarray:
-        """Blurs the area bounded by bbox in an image."""
+        Args:
+            inputs (dict): Dictionary of inputs with keys "img", "bboxes"
+
+        Returns:
+            outputs (dict): Output in dictionary format with key "img"
+        """
+        blurred_img = self._blur_bbox(inputs["img"], inputs["bboxes"])
+        outputs = {"img": blurred_img}
+        return outputs
+
+    def _blur_bbox(self, image: np.ndarray, bboxes: List[np.ndarray]) -> np.ndarray:
+        """Blurs areas bounded by bounding boxes on ``image``.
+
+        Args:
+            image (np.ndarray): Image in numpy array.
+            bboxes (List[np.ndarray]): numpy array of detected bboxes
+
+        Returns:
+            (np.ndarray): Image with blurred bounding box regions.
+        """
         height = image.shape[0]
         width = image.shape[1]
 
@@ -66,24 +83,12 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             bbox_image = image[y_1:y_2, x_1:x_2, :]
 
             # apply the blur using blur filter from opencv
-            blur_bbox_image = cv2.blur(bbox_image, (blur_kernel_size, blur_kernel_size))
+            blur_bbox_image = cv2.blur(
+                bbox_image, (self.blur_kernel_size, self.blur_kernel_size)
+            )
             image[y_1:y_2, x_1:x_2, :] = blur_bbox_image
 
         return image
-
-    def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Reads the image input and returns the image, with the areas bounded
-        by the bboxes blurred.
-
-        Args:
-            inputs (dict): Dictionary of inputs with keys "img", "bboxes"
-
-        Returns:
-            outputs (dict): Output in dictionary format with key "img"
-        """
-        blurred_img = self._blur(inputs["bboxes"], inputs["img"], self.blur_kernel_size)
-        outputs = {"img": blurred_img}
-        return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
         """Returns a dictionary which maps the node's config keys to their

--- a/peekingduck/pipeline/nodes/draw/blur_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/blur_bbox.py
@@ -91,7 +91,5 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return image
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"blue_kernel_size": int}

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -20,9 +20,9 @@ from typing import Any, Dict, List
 
 import numpy as np
 
+from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.draw.utils.bbox import draw_bboxes, draw_tags
 from peekingduck.pipeline.nodes.draw.utils.constants import TOMATO
-from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
 
 class Node(AbstractNode):
@@ -86,6 +86,12 @@ class Node(AbstractNode):
         draw_tags(inputs["img"], group_bboxes, group_tags, TOMATO)
 
         return {}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"tag": str}
 
     @staticmethod
     def _get_group_bbox_coords(

--- a/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
+++ b/peekingduck/pipeline/nodes/draw/group_bbox_and_tag.py
@@ -88,9 +88,7 @@ class Node(AbstractNode):
         return {}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"tag": str}
 
     @staticmethod

--- a/peekingduck/pipeline/nodes/draw/legend.py
+++ b/peekingduck/pipeline/nodes/draw/legend.py
@@ -18,8 +18,8 @@ Displays selected information from preceding nodes in a legend box.
 
 from typing import Any, Dict, List
 
-from peekingduck.pipeline.nodes.draw.utils.legend import Legend
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.draw.utils.legend import Legend
 
 
 class Node(AbstractNode):
@@ -88,6 +88,12 @@ class Node(AbstractNode):
         Legend().draw(inputs, self.show, self.position, self.box_opacity)
         # cv2 weighted does not update the referenced image. Need to return and replace.
         return {"img": inputs["img"]}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"position": str, "box_opacity": float, "show": List[str]}
 
 
 def _check_data_type(inputs: Dict[str, Any], show: List[str]) -> None:

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -58,6 +58,12 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         outputs = {"img": mosaic_img}
         return outputs
 
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"mosaic_level": int}
+
     def _mosaic_bbox(self, image: np.ndarray, bboxes: List[np.ndarray]) -> np.ndarray:
         """Mosaics areas bounded by bounding boxes on ``image``.
 

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -51,8 +51,6 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
 
-        self.mosaic_level = self.config["mosaic_level"]
-
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         mosaic_img = self._mosaic_bbox(inputs["img"], inputs["bboxes"])
         outputs = {"img": mosaic_img}

--- a/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
+++ b/peekingduck/pipeline/nodes/draw/mosaic_bbox.py
@@ -57,9 +57,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"mosaic_level": int}
 
     def _mosaic_bbox(self, image: np.ndarray, bboxes: List[np.ndarray]) -> np.ndarray:

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -18,10 +18,11 @@ import copy
 from typing import Any, Dict, List
 
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
-from peekingduck.pipeline.nodes.draw.utils.bbox import check_bgr_type, draw_tags
+from peekingduck.pipeline.nodes.base import ThresholdCheckerMixin
+from peekingduck.pipeline.nodes.draw.utils.bbox import draw_tags
 
 
-class Node(AbstractNode):
+class Node(ThresholdCheckerMixin, AbstractNode):
     """Draws a tag above each bounding box in the image, using information from
     selected attributes in :term:`obj_attrs`. In the general example below,
     :term:`obj_attrs` has 2 attributes (`<attr a>` and `<attr b>`). There are
@@ -94,8 +95,8 @@ class Node(AbstractNode):
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any) -> None:
         super().__init__(config, node_path=__name__, **kwargs)
+        self.check_bounds("tag_color", "[0, 255]")
         self.attr_keys = []
-        check_bgr_type(self.tag_color)
         if not self.show:
             raise KeyError(
                 "The 'show' config is currently empty. Add the desired attributes to be drawn "

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -17,8 +17,8 @@
 import copy
 from typing import Any, Dict, List
 
-from peekingduck.pipeline.nodes.draw.utils.bbox import check_bgr_type, draw_tags
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.draw.utils.bbox import check_bgr_type, draw_tags
 
 
 class Node(AbstractNode):
@@ -121,6 +121,12 @@ class Node(AbstractNode):
         draw_tags(inputs["img"], inputs["bboxes"], tags, self.tag_color)
 
         return {}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"show": List[str], "tag_color": List[int]}
 
     def _tags_from_obj_attrs(self, inputs: Dict[str, Any]) -> List[str]:
         """Process inputs from various attributes into tags for drawing."""

--- a/peekingduck/pipeline/nodes/draw/tag.py
+++ b/peekingduck/pipeline/nodes/draw/tag.py
@@ -124,9 +124,7 @@ class Node(ThresholdCheckerMixin, AbstractNode):
         return {}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"show": List[str], "tag_color": List[int]}
 
     def _tags_from_obj_attrs(self, inputs: Dict[str, Any]) -> List[str]:

--- a/peekingduck/pipeline/nodes/draw/utils/bbox.py
+++ b/peekingduck/pipeline/nodes/draw/utils/bbox.py
@@ -176,22 +176,3 @@ def draw_pts(frame: np.ndarray, pts: List[Tuple[float]]) -> None:
     """
     for point in pts:
         cv2.circle(frame, point, POINT_RADIUS, CHAMPAGNE, -1)
-
-
-def check_bgr_type(colors: List[int]) -> None:
-    """Check the type and range of provided colors.
-
-    Args:
-        colors (List[int]): Color in BGR format.
-    """
-    for color in colors:
-        if not isinstance(color, int):
-            raise TypeError(
-                f"Color values should be integers. The chosen value of: {color} is of type: "
-                f"{type(color)} instead."
-            )
-        if color < 0 or color > 255:
-            raise ValueError(
-                f"Color values should lie between (and include) 0 and 255. The chosen value of: "
-                f"{color} is not within this range."
-            )

--- a/peekingduck/pipeline/nodes/input/visual.py
+++ b/peekingduck/pipeline/nodes/input/visual.py
@@ -220,9 +220,7 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
                 self._file_name = path.name
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "buffering": bool,
             "filename": str,

--- a/peekingduck/pipeline/nodes/input/visual.py
+++ b/peekingduck/pipeline/nodes/input/visual.py
@@ -23,9 +23,9 @@ Reads inputs from multiple visual sources |br|
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.input.utils.preprocess import resize_image
 from peekingduck.pipeline.nodes.input.utils.read import VideoNoThread, VideoThread
-from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
 
 class SourceType:  # pylint: disable=too-few-public-methods
@@ -218,6 +218,24 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
             else:
                 self._source_type = SourceType.FILE
                 self._file_name = path.name
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "buffering": bool,
+            "filename": str,
+            "frames_log_freq": int,
+            "mirror_image": bool,
+            "resize": Dict[str, Union[bool, int]],
+            "resize.do_resizing": bool,
+            "resize.height": int,
+            "resize.width": int,
+            "saved_video_fps": int,
+            "source": Union[int, str],
+            "threading": bool,
+        }
 
     def _get_files(self, path: Path) -> None:
         """Read all files in given directory (non-recursive)

--- a/peekingduck/pipeline/nodes/input/visual.py
+++ b/peekingduck/pipeline/nodes/input/visual.py
@@ -61,7 +61,7 @@ class Node(AbstractNode):  # pylint: disable=too-many-instance-attributes
             overridden.
         mirror_image (:obj:`bool`): **default = False**. |br|
             Flag to set extracted image frame as mirror image of input stream.
-        resize (:obj:`Dict`):
+        resize (:obj:`Dict[str, Any]`):
             **default = { do_resizing: False, width: 1280, height: 720 }** |br|
             Dimension of extracted image frame.
         source (:obj:`Union[int, str]`):

--- a/peekingduck/pipeline/nodes/model/csrnet.py
+++ b/peekingduck/pipeline/nodes/model/csrnet.py
@@ -89,7 +89,5 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"model_type": str, "weights_parent_dir": Optional[str], "width": int}

--- a/peekingduck/pipeline/nodes/model/csrnet.py
+++ b/peekingduck/pipeline/nodes/model/csrnet.py
@@ -16,7 +16,7 @@
 networks for understanding the highly congested scenes.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import cv2
 
@@ -87,3 +87,9 @@ class Node(AbstractNode):
         density_map, crowd_count = self.model.predict(image)
         outputs = {"density_map": density_map, "count": crowd_count}
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"model_type": str, "weights_parent_dir": Optional[str], "width": int}

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -53,7 +53,7 @@ class Node(AbstractNode):
         score_threshold (:obj:`float`): **[0, 1], default = 0.3**.
             Bounding boxes with confidence score below the threshold will be
             discarded.
-        detect (:obj:`List[Union[int, string]]`): **default = [0]**. |br|
+        detect (:obj:`List[Union[int, str]]`): **default = [0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -83,9 +83,7 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "detect": List[Union[int, str]],
             "model_type": int,

--- a/peekingduck/pipeline/nodes/model/efficientdet.py
+++ b/peekingduck/pipeline/nodes/model/efficientdet.py
@@ -14,13 +14,13 @@
 
 """🔲 Scalable and efficient object detection."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import numpy as np
 
-from peekingduck.pipeline.nodes.model.efficientdet_d04 import efficientdet_model
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.model.efficientdet_d04 import efficientdet_model
 
 
 class Node(AbstractNode):
@@ -81,3 +81,14 @@ class Node(AbstractNode):
 
         outputs = {"bboxes": bboxes, "bbox_labels": labels, "bbox_scores": scores}
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "detect": List[Union[int, str]],
+            "model_type": int,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/fairmot.py
+++ b/peekingduck/pipeline/nodes/model/fairmot.py
@@ -16,12 +16,12 @@
 detection and re-ID tasks.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from peekingduck.pipeline.nodes.model.fairmotv1 import fairmot_model
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.model.fairmotv1 import fairmot_model
 
 
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
@@ -121,6 +121,19 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             "obj_attrs": {"ids": track_ids},
         }
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "input_size": List[int],
+            "K": int,
+            "min_box_area": int,
+            "score_threshold": float,
+            "track_buffer": int,
+            "weights_parent_dir": Optional[str],
+        }
 
     def _reset_model(self) -> None:
         """Creates a new instance of the FairMOT model with the frame rate

--- a/peekingduck/pipeline/nodes/model/fairmot.py
+++ b/peekingduck/pipeline/nodes/model/fairmot.py
@@ -123,9 +123,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "input_size": List[int],
             "K": int,

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -17,7 +17,7 @@ human pose estimation. Requires an object detector.
 """
 
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.model.hrnetv1 import hrnet_model
@@ -52,7 +52,7 @@ class Node(AbstractNode):
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
             Change the parent directory where weights will be stored by
             replacing ``null`` with an absolute path to the desired directory.
-        resolution (:obj:`Dict`):
+        resolution (:obj:`Dict[str, int]`):
             **default = { height: 192, width: 256 }**. |br|
             Resolution of input array to HRNet model.
         score_threshold (:obj:`float`): **[0, 1], default = 0.1**. |br|
@@ -81,3 +81,15 @@ class Node(AbstractNode):
             "keypoint_conns": keypoint_conns,
         }
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "resolution": Dict[str, int],
+            "resolution.height": int,
+            "resolution.width": int,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/hrnet.py
+++ b/peekingduck/pipeline/nodes/model/hrnet.py
@@ -83,9 +83,7 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "resolution": Dict[str, int],
             "resolution.height": int,

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -14,12 +14,12 @@
 
 """🎯 Joint Detection and Embedding model for human detection and tracking."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import numpy as np
 
-from peekingduck.pipeline.nodes.model.jdev1 import jde_model
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.model.jdev1 import jde_model
 
 
 class Node(AbstractNode):
@@ -114,6 +114,19 @@ class Node(AbstractNode):
             "bbox_labels": bbox_labels,
             "bbox_scores": bbox_scores,
             "obj_attrs": {"ids": track_ids},
+        }
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "iou_threshold": float,
+            "min_box_area": int,
+            "nms_threshold": float,
+            "score_threshold": float,
+            "track_buffer": int,
+            "weights_parent_dir": Optional[str],
         }
 
     def _reset_model(self) -> None:

--- a/peekingduck/pipeline/nodes/model/jde.py
+++ b/peekingduck/pipeline/nodes/model/jde.py
@@ -117,9 +117,7 @@ class Node(AbstractNode):
         }
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "iou_threshold": float,
             "min_box_area": int,

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -107,9 +107,7 @@ class Node(AbstractNode):
         }
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "iou_threshold": float,
             "min_box_area": int,

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -64,10 +64,6 @@ class Node(AbstractNode):
         weights_parent_dir (:obj:`Optional[str]`): **default = null**. |br|
             Change the parent directory where weights will be stored by
             replacing ``null`` with an absolute path to the desired directory.
-        resolution (:obj:`Dict`): **default = { height: 256, width: 256 }** |br|
-            Dictionary of resolutions of input array to different MoveNet models.
-            Only multipose allows dynamic shape in multiples of 32 (recommended
-            256). Default will be the resolution for multipose lightning model.
         bbox_score_threshold (:obj:`float`): **[0,1], default = 0.2** |br|
             Detected bounding box confidence score threshold, only boxes above
             threshold will be kept in the output.
@@ -109,11 +105,9 @@ class Node(AbstractNode):
     def _get_config_types(self) -> Dict[str, Any]:
         """Returns dictionary mapping the node's config keys to respective types."""
         return {
-            "iou_threshold": float,
-            "min_box_area": int,
+            "bbox_score_threshold": float,
+            "keypoint_score_threshold": float,
             "model_format": str,
-            "nms_threshold": float,
-            "score_threshold": float,
-            "track_buffer": int,
+            "model_type": str,
             "weights_parent_dir": Optional[str],
         }

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -51,6 +51,9 @@ class Node(AbstractNode):
         |bbox_labels_data|
 
     Configs:
+        model_format (:obj:`str`): **{"tensorflow", "tensorrt"},
+            default="tensorflow"** |br|
+            Defines the weights format of the model.
         model_type (:obj:`str`):
             **{"
             singlepose_lightning", "singlepose_thunder", "multipose_lightning"

--- a/peekingduck/pipeline/nodes/model/movenet.py
+++ b/peekingduck/pipeline/nodes/model/movenet.py
@@ -14,7 +14,7 @@
 
 """🕺 Fast Pose Estimation model."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import cv2
 import numpy as np
@@ -104,4 +104,18 @@ class Node(AbstractNode):
             "keypoints": keypoints,
             "keypoint_conns": keypoint_conns,
             "keypoint_scores": keypoint_scores,
+        }
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "iou_threshold": float,
+            "min_box_area": int,
+            "model_format": str,
+            "nms_threshold": float,
+            "score_threshold": float,
+            "track_buffer": int,
+            "weights_parent_dir": Optional[str],
         }

--- a/peekingduck/pipeline/nodes/model/mtcnn.py
+++ b/peekingduck/pipeline/nodes/model/mtcnn.py
@@ -109,9 +109,7 @@ class Node(AbstractNode):
         }
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "min_size": int,
             "network_thresholds": List[float],

--- a/peekingduck/pipeline/nodes/model/mtcnn.py
+++ b/peekingduck/pipeline/nodes/model/mtcnn.py
@@ -16,9 +16,10 @@
 with unmasked faces.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import numpy as np
+
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.model.mtcnnv1 import mtcnn_model
 
@@ -51,7 +52,7 @@ class Node(AbstractNode):
             Scale factor to create the image pyramid. A larger scale factor
             produces more accurate detections at the expense of inference
             speed.
-        network_thresholds (:obj:`List`):
+        network_thresholds (:obj:`List[float]`):
             **[0, 1], default = [0.6, 0.7, 0.7]**. |br|
             Threshold values for the Proposal Network (P-Net), Refine Network
             (R-Net) and Output Network (O-Net) in the MTCNN model.
@@ -105,4 +106,16 @@ class Node(AbstractNode):
             "bboxes": bboxes,
             "bbox_labels": bbox_labels,
             "bbox_scores": bbox_scores,
+        }
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "min_size": int,
+            "network_thresholds": List[float],
+            "scale_factor": float,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
         }

--- a/peekingduck/pipeline/nodes/model/mtcnn.py
+++ b/peekingduck/pipeline/nodes/model/mtcnn.py
@@ -70,16 +70,10 @@ class Node(AbstractNode):
 
         Model weights trained by https://github.com/blaueck/tf-mtcnn
 
-    .. versionchanged:: 1.2.0
-        ``mtcnn_min_size`` is renamed to ``min_size``.
-
-    .. versionchanged:: 1.2.0
-        ``mtcnn_factor`` is renamed to ``scale_factor``.
-
-    .. versionchanged:: 1.2.0
-        ``mtcnn_thresholds`` is renamed to ``network_thresholds``.
-
-    .. versionchanged:: 1.2.0
+    .. versionchanged:: 1.2.0 |br|
+        ``mtcnn_min_size`` is renamed to ``min_size``. |br|
+        ``mtcnn_factor`` is renamed to ``scale_factor``. |br|
+        ``mtcnn_thresholds`` is renamed to ``network_thresholds``. |br|
         ``mtcnn_score`` is renamed to ``score_threshold``.
     """
 

--- a/peekingduck/pipeline/nodes/model/posenet.py
+++ b/peekingduck/pipeline/nodes/model/posenet.py
@@ -92,9 +92,7 @@ class Node(AbstractNode):
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "max_pose_detection": int,
             "model_type": Union[str, int],

--- a/peekingduck/pipeline/nodes/model/posenet.py
+++ b/peekingduck/pipeline/nodes/model/posenet.py
@@ -14,7 +14,7 @@
 
 """🕺 Fast Pose Estimation model."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -90,3 +90,17 @@ class Node(AbstractNode):
             "keypoint_conns": keypoint_conns,
         }
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "max_pose_detection": int,
+            "model_type": Union[str, int],
+            "resolution": Dict[str, int],
+            "resolution.height": int,
+            "resolution.width": int,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -71,10 +71,8 @@ class Node(AbstractNode):
 
         Inference code adapted from https://github.com/zzh8829/yolov3-tf2
 
-    .. versionchanged:: 1.2.0
-        ``yolo_iou_threshold`` is renamed to ``iou_threshold``.
-
-    .. versionchanged:: 1.2.0
+    .. versionchanged:: 1.2.0 |br|
+        ``yolo_iou_threshold`` is renamed to ``iou_threshold``. |br|
         ``yolo_score_threshold`` is renamed to ``score_threshold``.
     """
 

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -48,7 +48,7 @@ class Node(AbstractNode):
             replacing ``null`` with an absolute path to the desired directory.
         num_classes (:obj:`int`): **default = 80**. |br|
             Maximum number of objects to be detected.
-        detect (:obj:`List[Union[int, string]]`): **default = [0]**. |br|
+        detect (:obj:`List[Union[int, str]]`): **default = [0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         max_output_size_per_class (:obj:`int`): **default = 50**. |br|

--- a/peekingduck/pipeline/nodes/model/yolo.py
+++ b/peekingduck/pipeline/nodes/model/yolo.py
@@ -14,7 +14,7 @@
 
 """🔲 One-stage Object Detection model."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import numpy as np
@@ -99,3 +99,15 @@ class Node(AbstractNode):
 
         outputs = {"bboxes": bboxes, "bbox_labels": labels, "bbox_scores": scores}
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        return {
+            "detect": List[Union[int, str]],
+            "iou_threshold": float,
+            "max_output_size_per_class": int,
+            "max_total_size": int,
+            "model_type": str,
+            "num_classes": int,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -16,13 +16,13 @@
 unmasked faces.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import cv2
 import numpy as np
 
-from peekingduck.pipeline.nodes.model.yolov4_face import yolo_face_model
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.model.yolov4_face import yolo_face_model
 
 
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
@@ -92,3 +92,17 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         }
 
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "detect": List[int],
+            "iou_threshold": float,
+            "max_output_size_per_class": int,
+            "max_total_size": int,
+            "model_type": str,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -69,10 +69,8 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         Model weights trained using pretrained weights from Darknet:
         https://github.com/AlexeyAB/darknet
 
-    .. versionchanged:: 1.2.0
-        ``yolo_iou_threshold`` is renamed to ``iou_threshold``.
-
-    .. versionchanged:: 1.2.0
+    .. versionchanged:: 1.2.0 |br|
+        ``yolo_iou_threshold`` is renamed to ``iou_threshold``. |br|
         ``yolo_score_threshold`` is renamed to ``score_threshold``.
     """
 

--- a/peekingduck/pipeline/nodes/model/yolo_face.py
+++ b/peekingduck/pipeline/nodes/model/yolo_face.py
@@ -94,9 +94,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "detect": List[int],
             "iou_threshold": float,

--- a/peekingduck/pipeline/nodes/model/yolo_license_plate.py
+++ b/peekingduck/pipeline/nodes/model/yolo_license_plate.py
@@ -62,10 +62,8 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         Model weights trained using pretrained weights from Darknet:
         https://github.com/AlexeyAB/darknet
 
-    .. versionchanged:: 1.2.0
-        ``yolo_iou_threshold`` is renamed to ``iou_threshold``.
-
-    .. versionchanged:: 1.2.0
+    .. versionchanged:: 1.2.0 |br|
+        ``yolo_iou_threshold`` is renamed to ``iou_threshold``. |br|
         ``yolo_score_threshold`` is renamed to ``score_threshold``.
     """
 

--- a/peekingduck/pipeline/nodes/model/yolo_license_plate.py
+++ b/peekingduck/pipeline/nodes/model/yolo_license_plate.py
@@ -96,9 +96,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "iou_threshold": float,
             "model_type": str,

--- a/peekingduck/pipeline/nodes/model/yolo_license_plate.py
+++ b/peekingduck/pipeline/nodes/model/yolo_license_plate.py
@@ -14,15 +14,15 @@
 
 """🔲 License Plate Detection model."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import cv2
 import numpy as np
 
+from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 from peekingduck.pipeline.nodes.model.yolov4_license_plate import (
     yolo_license_plate_model,
 )
-from peekingduck.pipeline.nodes.abstract_node import AbstractNode
 
 
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
@@ -94,3 +94,14 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         }
 
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "iou_threshold": float,
+            "model_type": str,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -14,12 +14,12 @@
 
 """🔲 High performance anchor-free YOLO object detection model."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
-from peekingduck.pipeline.nodes.model.yoloxv1 import yolox_model
 from peekingduck.pipeline.nodes.abstract_node import AbstractNode
+from peekingduck.pipeline.nodes.model.yoloxv1 import yolox_model
 
 
 class Node(AbstractNode):  # pylint: disable=too-few-public-methods
@@ -105,3 +105,20 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         outputs = {"bboxes": bboxes, "bbox_labels": labels, "bbox_scores": scores}
 
         return outputs
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "agnostic_nms": bool,
+            "detect": List[Union[int, str]],
+            "fuse": bool,
+            "half": bool,
+            "input_size": int,
+            "iou_threshold": float,
+            "model_format": str,
+            "model_type": str,
+            "score_threshold": float,
+            "weights_parent_dir": Optional[str],
+        }

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -42,6 +42,9 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         |bbox_scores_data|
 
     Configs:
+        model_format (:obj:`str`): **{"pytorch", "tensorrt"},
+            default="pytorch"** |br|
+            Defines the weights format of the model.
         model_type (:obj:`str`): **{"yolox-tiny", "yolox-s", "yolox-m",
             "yolox-l"}, default="yolox-tiny"**. |br|
             Defines the type of YOLOX model to be used.

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -53,7 +53,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
             replacing ``null`` with an absolute path to the desired directory.
         input_size (:obj:`int`): **default=416**. |br|
             Input image resolution of the YOLOX model.
-        detect (:obj:`List[Union[int, string]]`): **default=[0]**. |br|
+        detect (:obj:`List[Union[int, str]]`): **default=[0]**. |br|
             List of object class names or IDs to be detected. To detect all classes,
             refer to the :ref:`tech note <general-object-detection-ids>`.
         iou_threshold (:obj:`float`): **[0, 1], default = 0.45**. |br|

--- a/peekingduck/pipeline/nodes/model/yolox.py
+++ b/peekingduck/pipeline/nodes/model/yolox.py
@@ -107,9 +107,7 @@ class Node(AbstractNode):  # pylint: disable=too-few-public-methods
         return outputs
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "agnostic_nms": bool,
             "detect": List[Union[int, str]],

--- a/peekingduck/pipeline/nodes/output/csv_writer.py
+++ b/peekingduck/pipeline/nodes/output/csv_writer.py
@@ -120,9 +120,7 @@ class Node(AbstractNode):
         self._stats_checked = True
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"stats_to_track": List[str], "file_path": str, "logging_interval": int}
 
     def _reset(self) -> None:

--- a/peekingduck/pipeline/nodes/output/csv_writer.py
+++ b/peekingduck/pipeline/nodes/output/csv_writer.py
@@ -36,7 +36,7 @@ class Node(AbstractNode):
         |none_output_data|
 
     Configs:
-        stats_to_track (:obj:`List`):
+        stats_to_track (:obj:`List[str]`):
             **default = ["keypoints", "bboxes", "bbox_labels"]**. |br|
             Parameters to log into the CSV file. The chosen parameters must be
             present in the data pool.
@@ -118,6 +118,12 @@ class Node(AbstractNode):
         # update stats_to_track with valid stats found in data pool
         self.stats_to_track = valid
         self._stats_checked = True
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"stats_to_track": List[str], "file_path": str, "logging_interval": int}
 
     def _reset(self) -> None:
         del self.csv_logger

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -85,9 +85,7 @@ class Node(AbstractNode):
         return {}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {"output_dir": str}
 
     def _write(self, img: np.ndarray) -> None:

--- a/peekingduck/pipeline/nodes/output/media_writer.py
+++ b/peekingduck/pipeline/nodes/output/media_writer.py
@@ -84,6 +84,12 @@ class Node(AbstractNode):
 
         return {}
 
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {"output_dir": str}
+
     def _write(self, img: np.ndarray) -> None:
         if self._image_type == "image":
             cv2.imwrite(self._file_path_with_timestamp, img)

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -80,9 +80,7 @@ class Node(AbstractNode):
         return {"pipeline_end": False}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "window_name": str,
             "window_loc": Dict[str, int],

--- a/peekingduck/pipeline/nodes/output/screen.py
+++ b/peekingduck/pipeline/nodes/output/screen.py
@@ -16,7 +16,7 @@
 Shows the outputs on your display.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import cv2
 
@@ -35,12 +35,12 @@ class Node(AbstractNode):
     Configs:
         window_name (:obj:`str`): **default = "PeekingDuck"** |br|
             Name of the displayed window.
-        window_size (:obj:`Dict`):
+        window_size (:obj:`Dict[str, Union[bool, int]]`):
             **default = { do_resizing: False, width: 1280, height: 720 }** |br|
             Resizes the displayed window to the chosen width and weight, if
             ``do_resizing`` is set to ``true``. The size of the displayed
             window can also be adjusted by clicking and dragging.
-        window_loc (:obj:`Dict`): **default = { x: 0, y: 0 }** |br|
+        window_loc (:obj:`Dict[str, int]`): **default = { x: 0, y: 0 }** |br|
             X and Y coordinates of the top left corner of the displayed window,
             with reference from the top left corner of the screen, in pixels.
 
@@ -78,3 +78,18 @@ class Node(AbstractNode):
             return {"pipeline_end": True}
 
         return {"pipeline_end": False}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "window_name": str,
+            "window_loc": Dict[str, int],
+            "window_loc.x": int,
+            "window_loc.y": int,
+            "window_size": Dict[str, Union[bool, int]],
+            "window_size.do_resizing": bool,
+            "window_size.width": int,
+            "window_size.height": int,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ tensorflow >= 2.2, < 2.8
 torch == 1.10.0
 torchvision == 0.11.1
 tqdm == 4.45.0
+typeguard >= 2.13.3
 scipy >= 1.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     colorama == 0.4.4
     torch == 1.10.0
     torchvision == 0.11.1
+    typeguard >= 2.13.3
     scipy >= 1.4.1
 include_package_data = True
 

--- a/tests/pipeline/nodes/dabble/test_camera_calibration.py
+++ b/tests/pipeline/nodes/dabble/test_camera_calibration.py
@@ -17,19 +17,18 @@ Test for dabble camera calibration node
 """
 
 import gc
+
 import cv2
 import numpy as np
 import pytest
-from pathlib import Path
-from contextlib import contextmanager
 import tensorflow.keras.backend as K
-from tests.conftest import PKD_DIR, TEST_DATA_DIR, TEST_IMAGES_DIR, not_raises
 
 from peekingduck.pipeline.nodes.dabble.camera_calibration import (
     Node,
     _check_corners_validity,
     _get_box_info,
 )
+from tests.conftest import TEST_DATA_DIR, TEST_IMAGES_DIR, not_raises
 
 CORNER_DATA = ["corners_ok.npz", "image_too_small.npz", "not_in_box.npz"]
 CHECKERBOARD_IMAGES = ["checkerboard1.png", "checkerboard2.png"]
@@ -125,8 +124,8 @@ class TestCameraCalibration:
             assert all(type(val) == int for val in text_pos)
             assert type(pos_type) == int
 
-    def test_check_initialise_display_scales(self, camera_calibration_node):
-        camera_calibration_node._initialise_display_scales(1280)
+    def test_check_initialize_display_scales(self, camera_calibration_node):
+        camera_calibration_node._initialize_display_scales(1280)
         assert camera_calibration_node.display_scales
 
     def test_checkerboard_detection(self, camera_calibration_node, checkerboard_images):

--- a/tests/pipeline/nodes/dabble/test_tracking.py
+++ b/tests/pipeline/nodes/dabble/test_tracking.py
@@ -60,7 +60,7 @@ class TestTracking:
         tracking_config["tracking_type"] = "invalid type"
         with pytest.raises(ValueError) as excinfo:
             _ = Node(tracking_config)
-        assert str(excinfo.value) == "tracking_type must be one of ['iou', 'mosse']"
+        assert "tracking_type must be one of" in str(excinfo.value)
 
     def test_should_raise_for_invalid_iou_threshold(
         self, tracking_config_type, invalid_threshold
@@ -68,13 +68,13 @@ class TestTracking:
         tracking_config_type["iou_threshold"] = invalid_threshold
         with pytest.raises(ValueError) as excinfo:
             _ = Node(tracking_config_type)
-        assert str(excinfo.value) == "iou_threshold must be in [0, 1]"
+        assert str(excinfo.value) == "iou_threshold must be between [0.0, 1.0]"
 
     def test_should_raise_for_negative_max_lost(self, tracking_config_type):
         tracking_config_type["max_lost"] = -1
         with pytest.raises(ValueError) as excinfo:
             _ = Node(tracking_config_type)
-        assert str(excinfo.value) == "max_lost cannot be negative"
+        assert str(excinfo.value) == "max_lost must be between [0.0, inf)"
 
     def test_no_tags(self, create_image, tracker):
         img1 = create_image(SIZE)

--- a/tests/pipeline/nodes/dabble/test_zone_count.py
+++ b/tests/pipeline/nodes/dabble/test_zone_count.py
@@ -70,3 +70,17 @@ class TestBboxCount:
         assert len(results) == 2
         assert results[0] == 2
         assert results[1] == 2
+
+    def test_mixed_pixel_fraction_zone(self):
+        with pytest.raises(ValueError) as excinfo:
+            Node(
+                {
+                    "input": ["btm_midpoint"],
+                    "output": ["zones", "zone_count"],
+                    "resolution": [1280, 720],
+                    "zones": [[[0, 0], [640, 0], [1, 1], [0.5, 1]]],
+                }
+            )
+        assert "needs to be all pixel-wise points or all fractions" in str(
+            excinfo.value
+        )

--- a/tests/pipeline/nodes/draw/test_tag.py
+++ b/tests/pipeline/nodes/draw/test_tag.py
@@ -17,6 +17,7 @@ Test for draw tag node
 """
 
 from contextlib import contextmanager
+
 import numpy as np
 import pytest
 
@@ -147,21 +148,24 @@ class TestTag:
         tag_config["tag_color"] = [128, -1, 128]
         with pytest.raises(ValueError) as excinfo:
             Node(tag_config)
-        assert "Color values should lie between (and include) 0 and 255" in str(
+        assert "All elements of tag_color must be between [0.0, 255.0]" in str(
             excinfo.value
         )
 
         tag_config["tag_color"] = [128, 256, 128]
         with pytest.raises(ValueError) as excinfo:
             Node(tag_config)
-        assert "Color values should lie between (and include) 0 and 255" in str(
+        assert "All elements of tag_color must be between [0.0, 255.0]" in str(
             excinfo.value
         )
 
         tag_config["tag_color"] = [128, 128.0, 128]
         with pytest.raises(TypeError) as excinfo:
             Node(tag_config)
-        assert "Color values should be integers" in str(excinfo.value)
+        assert (
+            "type of draw.tag's `tag_color`[1] must be int; got float instead"
+            in str(excinfo.value)
+        )
 
     def test_show_config_unchanged_between_frames(self, tag_config, create_image):
         # Each attr_key of the "show" config is obtained by recursion, where items in the

--- a/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
+++ b/tests/pipeline/nodes/model/efficientdet_d04/test_efficientdet.py
@@ -40,7 +40,6 @@ def efficientdet_config():
         {"key": "score_threshold", "value": -0.5},
         {"key": "score_threshold", "value": 1.5},
         {"key": "model_type", "value": 5},
-        {"key": "model_type", "value": 1.5},
     ],
 )
 def efficientdet_bad_config_value(request, efficientdet_config):
@@ -127,3 +126,12 @@ class TestEfficientDet:
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=efficientdet_bad_config_value)
         assert "must be" in str(excinfo.value)
+
+    def test_invalid_model_type(self, efficientdet_config):
+        efficientdet_config["model_type"] = 1.5
+        with pytest.raises(TypeError) as excinfo:
+            _ = Node(config=efficientdet_config)
+        assert (
+            str(excinfo.value)
+            == "type of model.efficientdet's `model_type` must be int; got float instead"
+        )

--- a/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
+++ b/tests/pipeline/nodes/model/fairmotv1/test_fairmot.py
@@ -48,12 +48,25 @@ def fairmot_config_gpu():
     params=[
         {"key": "score_threshold", "value": -0.5},
         {"key": "score_threshold", "value": 1.5},
-        {"key": "K", "value": -0.5},
-        {"key": "min_box_area", "value": -0.5},
-        {"key": "track_buffer", "value": -0.5},
+        {"key": "K", "value": -1},
+        {"key": "min_box_area", "value": -1},
+        {"key": "track_buffer", "value": -1},
     ],
 )
 def fairmot_bad_config_value(request, fairmot_config):
+    """Various invalid config values."""
+    fairmot_config[request.param["key"]] = request.param["value"]
+    return fairmot_config
+
+
+@pytest.fixture(
+    params=[
+        {"key": "K", "value": 0.5},
+        {"key": "min_box_area", "value": 0.5},
+        {"key": "track_buffer", "value": 0.5},
+    ],
+)
+def fairmot_bad_config_type(request, fairmot_config):
     """Various invalid config values."""
     fairmot_config[request.param["key"]] = request.param["value"]
     return fairmot_config
@@ -258,6 +271,11 @@ class TestFairMOT:
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=fairmot_bad_config_value)
         assert "must be" in str(excinfo.value)
+
+    def test_invalid_config_type(self, fairmot_bad_config_type):
+        with pytest.raises(TypeError) as excinfo:
+            _ = Node(config=fairmot_bad_config_type)
+        assert "type of model.fairmot's" in str(excinfo.value)
 
     @mock.patch.object(WeightsDownloaderMixin, "_has_weights", return_value=True)
     def test_invalid_config_model_files(self, _, fairmot_config):

--- a/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
+++ b/tests/pipeline/nodes/model/mtcnnv1/test_mtcnn.py
@@ -39,7 +39,7 @@ def mtcnn_config():
 
 @pytest.fixture(
     params=[
-        {"key": "min_size", "value": -0.5},
+        {"key": "min_size", "value": -1},
         {"key": "network_thresholds", "value": [-0.5, -0.5, -0.5]},
         {"key": "network_thresholds", "value": [1.5, 1.5, 1.5]},
         {"key": "scale_factor", "value": -0.5},
@@ -88,6 +88,12 @@ class TestMTCNN:
         with pytest.raises(ValueError) as excinfo:
             _ = Node(config=mtcnn_bad_config_value)
         assert "must be" in str(excinfo.value)
+
+    def test_invalid_config_type(self, mtcnn_config):
+        mtcnn_config["min_size"] = 0.5
+        with pytest.raises(TypeError) as excinfo:
+            _ = Node(config=mtcnn_config)
+        assert "type of model.mtcnn's" in str(excinfo.value)
 
     @mock.patch.object(WeightsDownloaderMixin, "_has_weights", return_value=True)
     def test_invalid_config_model_files(self, _, mtcnn_config):

--- a/tests/pipeline/nodes/output/test_csv_writer.py
+++ b/tests/pipeline/nodes/output/test_csv_writer.py
@@ -35,7 +35,7 @@ def writer():  # logging interval of 1 second
             "output": "end",
             "file_path": str(Path.cwd() / "test1.csv"),
             "stats_to_track": ["bbox", "bbox_labels"],
-            "logging_interval": "1",
+            "logging_interval": 1,
         }
     )
     return csv_writer
@@ -50,7 +50,7 @@ def writer2():  # logging interval of 5 second
             "output": "end",
             "file_path": str(Path.cwd() / "test2.csv"),
             "stats_to_track": ["bbox", "bbox_labels"],
-            "logging_interval": "5",
+            "logging_interval": 5,
         }
     )
     return csv_writer

--- a/tests/pipeline/nodes/output/test_media_writer.py
+++ b/tests/pipeline/nodes/output/test_media_writer.py
@@ -33,7 +33,9 @@ def directory_contents():
 
 @pytest.fixture
 def writer():
-    media_writer = Node({"output_dir": OUTPUT_PATH, "input": "img", "output": "none"})
+    media_writer = Node(
+        {"output_dir": str(OUTPUT_PATH), "input": "img", "output": "none"}
+    )
     return media_writer
 
 

--- a/tests/pipeline/nodes/test_node.py
+++ b/tests/pipeline/nodes/test_node.py
@@ -28,9 +28,7 @@ class ConcreteNode(AbstractNode):
         return {"data1": 1, "data2": 42}
 
     def _get_config_types(self) -> Dict[str, Any]:
-        """Returns a dictionary which maps the node's config keys to their
-        respective typing.
-        """
+        """Returns dictionary mapping the node's config keys to respective types."""
         return {
             "buffering": bool,
             "filename": str,

--- a/tests/pipeline/nodes/test_node.py
+++ b/tests/pipeline/nodes/test_node.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import Any, Dict, Union
 
 import pytest
 
@@ -26,6 +26,24 @@ class ConcreteNode(AbstractNode):
 
     def run(self, inputs: Dict):
         return {"data1": 1, "data2": 42}
+
+    def _get_config_types(self) -> Dict[str, Any]:
+        """Returns a dictionary which maps the node's config keys to their
+        respective typing.
+        """
+        return {
+            "buffering": bool,
+            "filename": str,
+            "frames_log_freq": int,
+            "mirror_image": bool,
+            "resize": Dict[str, Union[bool, int]],
+            "resize.do_resizing": bool,
+            "resize.height": int,
+            "resize.width": int,
+            "saved_video_fps": int,
+            "source": Union[int, str],
+            "threading": bool,
+        }
 
 
 class IncorrectNode(AbstractNode):
@@ -84,6 +102,21 @@ class TestNode:
     def test_node_no_concrete_run_raises_error(self):
         with pytest.raises(TypeError):
             IncorrectNode({})
+
+    def test_node_wrong_config_type(self):
+        with pytest.raises(TypeError) as excinfo:
+            ConcreteNode(config={"source": 0.0})
+        assert (
+            "type of input.visual's `source` must be one of (int, str); got float instead"
+            == str(excinfo.value)
+        )
+
+        with pytest.raises(TypeError) as excinfo:
+            ConcreteNode(config={"resize": {"do_resizing": True, "height": 0.0}})
+        assert (
+            "type of input.visual's `resize.height` must be int; got float instead"
+            == str(excinfo.value)
+        )
 
     #
     # Test class name to object ID translation for different input cases


### PR DESCRIPTION
Closes https://github.com/aimakerspace/PeekingDuck-Private/issues/73

**Feature**:
- Add `typeguard >= 2.13.3` as new dependency
- Add `_check_type()` method to `AbstractNode`, called before setting the nodes' instance attributes
  - `TypeError` will be raised for wrong config types. The message is formatted as `type of <node type>.<node name>'s <config key> must be <type>; got <user type> instead`
- Add `_get_config_types()` method in `AbstractNode`
  - Nodes with user-configurable config options will override this method and return a dictionary of `<config key>: <config type hint>`
  - For `config key` which is a dictionary, the types of each sub-key is written as: `<config key>.<sub-key>: <sub-config type hint>`. An example is `input.visual`'s `resize` config
- Add tests in `test_node.py` and refactor some model invalid config tests as this check occurs before invalid value checks

**Refactor and bugfix**
- Remove existing `try ... except TypeError` in `dabble.zone_count`
- Fix `_create_zone()` logic in `dabble.zone_count` to avoid edge case of creating a 1 pixel by 1 pixel zone
- Remove unnecessary instance attribute initialization in `draw.blur_bbox` and `draw.mosaic_bbox`
- Remove `bgr_check()` in `draw.tag`, use `check_bounds()` instead
- Make `DetectionTracker` (part of `dabble.tracking`) inherit `ThresholdCheckerMixin`
- Remove unused config options from `draw.group_bbox_and_tag` and `draw.poses`.
- Add `model_format` as user_configurable key to `model.movenet` and `model.yolox`